### PR TITLE
feat: add sql run component for hypertrons.

### DIFF
--- a/.github/hypertrons-components/sql_run/config.ts
+++ b/.github/hypertrons-components/sql_run/config.ts
@@ -1,0 +1,66 @@
+// Copyright 2019 - present Xlab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { configClass, configProp } from '../../config-generator/decorators';
+import defaultConfig from './defaultConfig';
+
+@configClass({
+  description: 'Auto merge schedule config',
+})
+export default class Config {
+  @configProp({
+    description: 'Request url for run sql',
+    defaultValue: defaultConfig.sqlRequestUrl,
+  })
+  sqlRequestUrl: string;
+
+  @configProp({
+    description: 'Run sql command',
+    defaultValue: defaultConfig.command,
+  })
+  command: string;
+
+  @configProp({
+    description: 'Regex to find sql file',
+    defaultValue: defaultConfig.sqlFileRegex,
+  })
+  sqlFileRegex: string;
+
+  @configProp({
+    description: 'Regex to find post processor file',
+    defaultValue: defaultConfig.postProcessFileRegex,
+  })
+  postProcessFileRegex: string;
+
+  @configProp({
+    description: 'Regex to find manifest file',
+    defaultValue: defaultConfig.manifestFileRegex,
+  })
+  manifestFileRegex: string;
+
+  @configProp({
+    description: 'SQL & report render params',
+    defaultValue: defaultConfig.defaultRenderParams,
+    type: 'any',
+  })
+  defaultRenderParams: any;
+
+  @configProp({
+    description: 'The item for render a SQL run result',
+    type: 'render_string',
+    renderParams: [ 'sqlName', 'data', 'text' ],
+    defaultValue: defaultConfig.commentItemTemplate,
+  })
+  commentItemTemplate: string;
+}

--- a/.github/hypertrons-components/sql_run/defaultConfig.ts
+++ b/.github/hypertrons-components/sql_run/defaultConfig.ts
@@ -1,0 +1,40 @@
+// Copyright 2019 - present Xlab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Config from './config';
+
+const defaultConfig: Config = {
+  sqlRequestUrl: 'http://localhost:7001/query',
+  command: '/sql-run',
+  sqlFileRegex: 'sqls/([%w|-]+)/sql',
+  manifestFileRegex: 'sqls/([%w|-]+)/manifest%.json',
+  postProcessFileRegex: 'sqls/([%w|-]+)/post%-processor%.js',
+  defaultRenderParams: {
+    year: 2020,
+    table: 'github_log.year2020',
+  },
+  commentItemTemplate: `I found SQL component \`{{sqlName}}\` in this PR, the SQL run result data is:
+\`\`\`
+{{data}}
+\`\`\`
+The renderred text is:
+
+{{text}}
+
+Please check whether the result is as expected.
+
+`,
+};
+
+export default defaultConfig;

--- a/.github/hypertrons-components/sql_run/index.lua
+++ b/.github/hypertrons-components/sql_run/index.lua
@@ -1,0 +1,86 @@
+-- Copyright 2019 - present Xlab
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- run sql for pull
+
+on('CommandEvent', function (e)
+  wrap(function()
+    if (e.command == compConfig.command) then
+      local prNumer = e.number;
+      local files = listPullRequestFiles(e.number)
+      log('Gonna run sql for '..e.number..', find '..#files..' files in PR')
+      if (#files == 0) then
+        return
+      end
+      local sqls = {}
+      for i=1, #files do
+        local filename = files[i].filename
+        local contentsUrl = files[i].contents_url
+
+        local setField = function(regex, key)
+          local sqlName = string.match(filename, regex)
+          if (sqlName ~= nil) then
+            log('match '..key)
+            local ref = string.match(contentsUrl, '.*?ref=(%w+)')
+            if (ref ~= nil) then
+              if (sqls[sqlName] == nil) then
+                sqls[sqlName] = {}
+              end
+              sqls[sqlName][key] = getFileContent(filename, ref).content
+            end
+          end
+        end
+        
+        setField(compConfig.sqlFileRegex, 'sql')
+        setField(compConfig.manifestFileRegex, 'manifest')
+        setField(compConfig.postProcessFileRegex, 'postProcessor')
+      end
+      
+      -- if only part component changed, read the origin files to complete the component
+      for k, v in pairs(sqls) do
+        if (v.sql == nil) then
+          v.sql = getFileContent('sqls/'..k..'/sql').content
+        end
+        if (v.manifest == nil) then
+          v.manifest = getFileContent('sqls/'..k..'/manifest.json').content
+        end
+        if (v.postProcessor == nil) then
+          v.postProcessor = getFileContent('sqls/'..k..'/post-processor.js').content
+        end
+      end
+
+      -- Render comment and add comment
+      local comment = '';
+      for k, v in pairs(sqls) do
+        local sql = rendStr(v.sql, string2table(v.manifest).config, compConfig.defaultRenderParams)
+        local requestRes = requestUrl({
+          ['url'] = compConfig.sqlRequestUrl,
+          ['method'] = 'POST',
+          ['form'] = {
+            ['query'] = sql
+          }
+        })
+        local text = runJsCode(v.postProcessor, string2table(requestRes).data)
+        log('Sql run done for '..k)
+        comment = comment..rendStr(compConfig.commentItemTemplate, {
+          ['text'] = text,
+          ['sqlName'] = k,
+          ['data'] = requestRes
+        })
+      end
+
+      addIssueComment(e.number, comment)
+    end
+  end)
+end)

--- a/.github/hypertrons-components/sql_run/version.json
+++ b/.github/hypertrons-components/sql_run/version.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "minAPIVersion": 0,
+  "maxAPIVersion": 1
+}

--- a/.github/hypertrons.json
+++ b/.github/hypertrons.json
@@ -147,5 +147,8 @@
   },
   "auto_update_report": {
     "version": 1
+  },
+  "sql_run": {
+    "version": 1
   }
 }


### PR DESCRIPTION
Signed-off-by: Frankzhaopku <syzhao1988@126.com>

Close #13 , when sql reviewer comment `/sql-run` command in a PR with SQL related files committed, like `sql`, `manifest.json`, `post-processor.js`, hypertrons will run the SQL with new config and return the result by comment to check if it is as expected.