### PR TITLE
[Fix] language distribution column name fix

### DIFF
--- a/global-study/sqls/repo-language-distribution/processor.js
+++ b/global-study/sqls/repo-language-distribution/processor.js
@@ -100,7 +100,7 @@ LIMIT ${topN_language}
   
   const data = await utils.queryGitHubEventLog(query);
 
-  const keys = ['repo_language', 'count', 'top_repo', 'activity', 'actor_count'];
+  const keys = ['language', 'count', 'top_repo', 'activity', 'actor_count'];
   
   return {
     html: `


### PR DESCRIPTION
Signed-off-by: Frankzhaopku <syzhao1988@126.com>

In last version, `repo_language` is not correct column name which will cause render error and the content will all be `undefined`. Fix the column name into `language`.