### PR TITLE
[Feature] Support unit test for single case study

### DIFF
--- a/src/case-study.ts
+++ b/src/case-study.ts
@@ -2,18 +2,27 @@ import { existsSync, mkdirSync, readdirSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { generateReport, readFileAsObj } from './utils';
 
-export async function caseStudy(): Promise<string[]> {
+export async function caseStudy(): Promise<void> {
+
+  if (process.argv[2] && process.argv[2].toLocaleLowerCase() === 'global') return;
+
   console.log('Start to generate case study.');
 
-  const files: string[] = [];
   
   const casesDir = join(__dirname, '../case-study/cases');
   if (!existsSync(casesDir)) {
-    return files;
+    return;
+  }
+
+  let caseParams: string[] = [];
+  if (process.argv.length > 2) {
+    caseParams = process.argv.slice(2);
+    console.log(caseParams);
   }
 
   const cases = readdirSync(casesDir);
   for (const c of cases) {
+    if (caseParams.length > 0 && !caseParams.some(p => p.toLocaleLowerCase() === c.toLocaleLowerCase().split('.')[0])) continue;
     const config = readFileAsObj(join(casesDir, c));
     if (config === null) continue;
     const reportContent = await generateReport({
@@ -31,7 +40,5 @@ export async function caseStudy(): Promise<string[]> {
     writeFileSync(outputFile, reportContent);
 
     console.log(`Generate case study into ${outputFile}`);
-    files.push(outputFile);
   }
-  return files;
 }

--- a/src/global-study.ts
+++ b/src/global-study.ts
@@ -2,7 +2,9 @@ import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { generateReport, readFileAsObj } from './utils';
 
-export async function globalStudy() {
+export async function globalStudy(): Promise<void> {
+  if (process.argv[2] && process.argv[2].toLocaleLowerCase() !== 'global') return;
+
   console.log('Start to generate global study.');
 
   const config = readFileAsObj(join(__dirname, '../global-study/config.yaml')) ?? {};
@@ -22,5 +24,4 @@ export async function globalStudy() {
   writeFileSync(globalStudyFile, reportContent);
 
   console.log(`Generate global study into ${globalStudyFile}`);
-  return globalStudy;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { globalStudy } from './global-study';
   const runType = process.env.RUN_TYPE;
   if (runType === 'test') {
     const distDir = join(__dirname, '../dist');
+    if (!existsSync(distDir)) return;
     const files = readdirSync(distDir);
     files.forEach(f => {
       if (f.endsWith('.html')) {


### PR DESCRIPTION
Signed-off-by: Frankzhaopku <syzhao1988@126.com>

Support unit test for single or specific case studies in command line.

- If you want to run all tests, you can run `npm run test`.
- If you want to generate only global report, you can run `npm run test global`.
- If you want to generate specific case study reports, you can add all case study names as params which are case insensitive like `npm run test vscode asf`, so the test will generate test reports for `ASF.yaml` and `vscode.yaml`.

close #568 