### PR TITLE
[CI] Use online data set as CI data set

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Test
         if: ${{ steps.regex-match.outputs.match != '' }}
         env:
-          CLICKHOUSE_CI_HOST: ${{ secrets.CLICKHOUSE_CI_HOST }}
+          CLICKHOUSE_QUERY_URL: ${{ secrets.CLICKHOUSE_QUERY_URL }}
         run: |
           npm install
           npm run ci

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Generate report
         env:
-          CLIKCKHOUSE_QUERY_URL: ${{ secrets.CLIKCKHOUSE_QUERY_URL }}
+          CLICKHOUSE_QUERY_URL: ${{ secrets.CLICKHOUSE_QUERY_URL }}
         run: |
           npm install
           npm run publish

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "scripts": {
     "build": "tsc",
     "test": "npm run clean && npm run build && RUN_TYPE=test node src/index.js",
-    "ci": "npm run clean && npm run build && RUN_TYPE=ci GITHUB_LOG_HOST=$CLICKHOUSE_CI_HOST node src/index.js",
-    "publish": "npm run clean && npm run build && RUN_TYPE=publish GITHUB_LOG_URL=$CLIKCKHOUSE_QUERY_URL node src/index.js",
+    "ci": "npm run clean && npm run build && RUN_TYPE=ci GITHUB_LOG_URL=$CLICKHOUSE_QUERY_URL node src/index.js",
+    "publish": "npm run clean && npm run build && RUN_TYPE=publish GITHUB_LOG_URL=$CLICKHOUSE_QUERY_URL node src/index.js",
     "data-docker": "docker pull docker-hub.x-lab.info/opendigger/github-sample-log:2.202105 && docker start github-sample-log || docker run -d --name github-sample-log -p 8123:8123 -p 9000:9000 --ulimit nofile=262144:262144 docker-hub.x-lab.info/opendigger/github-sample-log:2.202105",
     "clean": "rm -rf dist"
   },


### PR DESCRIPTION
Signed-off-by: Frankzhaopku <syzhao1988@126.com>

In last workflow we use test data set for CI test on PR which will cause empty result for repos, so we need to update data set to online full data set to get the real result.