### PR TITLE
[Feature] Fetch repo and org id for issues

### DIFF
--- a/.github/workflows/parse_github_id.yml
+++ b/.github/workflows/parse_github_id.yml
@@ -1,0 +1,76 @@
+name: paser-github-id
+
+on:
+  issue_comment:
+    types: [created]
+  # Allows to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  pr-test:
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Check comment command
+        uses: actions-ecosystem/action-regex-match@v2
+        id: regex-match
+        with:
+          text: ${{ github.event.comment.body }}
+          regex: '^/parse-github-id$'
+
+      - uses: actions/github-script@v3
+        id: parse-repo-org-id
+        if: ${{ steps.regex-match.outputs.match != '' }}
+        with:
+          script: |
+            const body = context.payload.issue.body;
+            if (!body || body === '') {
+              core.setFailed('Body is empty for this issue.');
+              return;
+            }
+            const lines = body.split('\r\n');
+            const commentBodyArr = [];
+            for (const line of lines) {
+              if (line.trim().startsWith('- ')) {
+                const name = line.trim().substring(2);
+                let result;
+                let type;
+                try {
+                  if (name.includes('/')) {
+                    const [owner, repo] = name.split('/');
+                    result = await github.repos.get({owner, repo});
+                    type = 'repo';
+                  } else {
+                    try {
+                      result = await github.orgs.get({org: name});
+                      type = 'org';
+                    } catch {
+                      result = await github.users.getByUsername({username: name});
+                      type = 'user';
+                    }
+                  }
+                  if (!(result && result.data)) {
+                    commentBodyArr.push(line);
+                  } else {
+                    core.info(`${name}: ${result.data.id}`);
+                    commentBodyArr.push(`- ${result.data.id} # ${type}:${name} `);
+                  }
+                } catch (err) {
+                  commentBodyArr.push(line + ' # not found');
+                }
+              } else {
+                commentBodyArr.push(line);
+              }
+            }
+            return commentBodyArr.join('<br />');
+
+      - name: Create comment
+        if: ${{ steps.regex-match.outputs.match != '' }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            Get repo and org/user ids done.
+
+            ${{ steps.parse-repo-org-id.outputs.result }}


### PR DESCRIPTION
Signed-off-by: Frankzhaopku <syzhao1988@126.com>

close #682 

Add a new GitHub Actions workflow to parse issue body and fetch repo/org/user's GitHub id automatically.

- The work should be triggered by command `/parse-github-id`.
- It will parse the issue body line by line and get the lines start with `- ` which is a list item in Markdown.
- It will fetch repo/org/user id by GitHub Rest API and reform the issue comment by original body, replace the name by id and add a yaml style comment with the type and name.

An example can be found [here](https://github.com/frank-zsy/open-digger/issues/4).