### PR TITLE
[Feat] Add open leaderboard tasks

### DIFF
--- a/labeled_data/regions/China.yml
+++ b/labeled_data/regions/China.yml
@@ -27,6 +27,8 @@ data:
     - :companies/vesoft
     - :companies/dcloud
     - :companies/qingcloud
+    - :companies/antgroup
+    - :companies/fit2cloud
     - :communities/xlab
     - :projects/skywalking
   github_org:

--- a/src/cron/tasks/hacking_force_month.ts
+++ b/src/cron/tasks/hacking_force_month.ts
@@ -19,7 +19,7 @@ const task: Task = {
         ranks: [],
       };
     });
-    forEveryMonth(2015, 1, 2021, 12, (y, m) => {
+    forEveryMonth(2015, 1, 2021, 12, async (y, m) => {
       const rankIndex = `open_rank_${y}${m}`;
       const sortArr = users.sort((a, b) => (b[rankIndex] ?? 0) - (a[rankIndex] ?? 0));
       result.forEach(r => {

--- a/src/cron/tasks/hypercrx_actor.ts
+++ b/src/cron/tasks/hypercrx_actor.ts
@@ -25,7 +25,7 @@ const task: Task = {
           activity: {},
           influence: {},
         };
-        forEveryMonth(2015, 1, year, month, (y, m) => {
+        forEveryMonth(2015, 1, year, month, async (y, m) => {
           userInfo.activity[`${y}-${m}`] = user[`activity_${y}${m}`] ?? 0;
           userInfo.influence[`${y}-${m}`] = user[`open_rank_${y}${m}`] ?? 0;
         });

--- a/src/cron/tasks/hypercrx_repo.ts
+++ b/src/cron/tasks/hypercrx_repo.ts
@@ -27,7 +27,7 @@ const task: Task = {
           activity: {},
           influence: {},
         };
-        forEveryMonth(2015, 1, year, month, (y, m) => {
+        forEveryMonth(2015, 1, year, month, async (y, m) => {
           repoInfo.activity[`${y}-${m}`] = repo[`activity_${y}${m}`] ?? 0;
           repoInfo.influence[`${y}-${m}`] = repo[`open_rank_${y}${m}`] ?? 0;
         });

--- a/src/cron/tasks/open_leaderboard.ts
+++ b/src/cron/tasks/open_leaderboard.ts
@@ -1,0 +1,370 @@
+import { writeFileSync } from 'fs';
+import { Task } from '..';
+import { query } from '../../db/neo4j';
+import { getGitHubData, getLabelData } from '../../label_data_utils';
+import { getRepoActivityWithDetail, getUserActivityWithDetail } from '../../metrics/activity_openrank';
+import { forEveryMonth } from '../../metrics/basic';
+import { rankData } from '../../utils';
+
+const task: Task = {
+  cron: '0 0 15 * *',    // runs on the 15th day of every month at 00:00
+  enable: true,
+  immediate: false,
+  callback: async () => {
+
+    console.log(`Start to run open leaderboard task.`);
+
+    const labelData = getLabelData();
+    const startYear = 2015, startMonth = 1, endYear = new Date().getFullYear(), endMonth = new Date().getMonth();
+    const limit = 300;
+    const allMonthes: string[] = [];
+    forEveryMonth(startYear, startMonth, endYear, endMonth, async (y, m) => allMonthes.push(`${y}${m}`));
+    const allYears = Array.from({ length: endYear - startYear + 1 }, (_, i) => i + startYear);
+    const monthInAYear = Array.from({ length: 12 }, (_, i) => i + 1 );
+
+    const writeData = (dataMap: Map<any, any>, type: string, path: string) => {
+      for (const [ time, data ] of dataMap.entries()) {
+        writeFileSync(`./local_files/open_index/${path}/${time}.json`, JSON.stringify({
+          type, time, data,
+        }));
+      }
+    };
+
+    // get chinese actor activity
+    const chineseUserMonthActivityData = await getUserActivityWithDetail({
+      labelUnion: [':regions/China'],
+      startYear, startMonth, endYear, endMonth,
+      order: 'DESC', limit: -1, percision: 2,
+      groupTimeRange: 'month',
+    });
+    const chineseUserMonthActivityMap = rankData(chineseUserMonthActivityData!, allMonthes, (item, _, index) => item.activity[index], (item, index) => {
+      return {
+        name: item.login,
+        id: item.id,
+        ...item.details[index],
+      }
+    });
+    for (const k of chineseUserMonthActivityMap.keys()) {
+      chineseUserMonthActivityMap.set(k, chineseUserMonthActivityMap.get(k)!.filter(i => i.value > 0));
+    }
+    writeData(chineseUserMonthActivityMap, 'Actor_China_Month', 'activity/actor/chinese');
+
+    const chineseUserYearActivityData = await getUserActivityWithDetail({
+      labelUnion: [':regions/China'],
+      startYear, startMonth, endYear, endMonth,
+      order: 'DESC', limit: -1, percision: 2,
+      groupTimeRange: 'year',
+    });
+    const chineseUserYearActivityMap = rankData(chineseUserYearActivityData!, allYears, (item, _, index) => item.activity[index], (item, index) => {
+      return {
+        name: item.login,
+        id: item.id,
+        ...item.details[index],
+      }
+    });
+    for (const k of chineseUserYearActivityMap.keys()) {
+      chineseUserYearActivityMap.set(k, chineseUserYearActivityMap.get(k)!.filter(i => i.value > 0));
+    }
+    writeData(chineseUserYearActivityMap, 'Actor_China_Year', 'activity/actor/chinese');
+    console.log('Chinese actor activity done.');
+
+    // get global actor activity
+    const globalUserMonthActivityData = await getUserActivityWithDetail({
+      startYear, startMonth, endYear, endMonth,
+      order: 'DESC', limit, percision: 2,
+      groupTimeRange: 'month',
+    });
+    const globalUserMonthActivityMap = rankData(globalUserMonthActivityData!, allMonthes, (item, _, index) => item.activity[index], (item, index) => {
+      return {
+        name: item.login,
+        id: item.id,
+        ...item.details[index],
+      }
+    });
+    for (const k of globalUserMonthActivityMap.keys()) {
+      globalUserMonthActivityMap.set(k, globalUserMonthActivityMap.get(k)!.filter(i => i.value > 0));
+    }
+    writeData(globalUserMonthActivityMap, 'Actor_Global_Month', 'activity/actor/global');
+
+    const globalUserYearActivityData = await getUserActivityWithDetail({
+      startYear, startMonth, endYear, endMonth,
+      order: 'DESC', limit, percision: 2,
+      groupTimeRange: 'year',
+    });
+    const globalUserYearActivityMap = rankData(globalUserYearActivityData!, allYears, (item, _, index) => item.activity[index], (item, index) => {
+      return {
+        name: item.login,
+        id: item.id,
+        ...item.details[index],
+      }
+    });
+    for (const k of globalUserYearActivityMap.keys()) {
+      globalUserYearActivityMap.set(k, globalUserYearActivityMap.get(k)!.filter(i => i.value > 0));
+    }
+    writeData(globalUserYearActivityMap, 'Actor_Global_Year', 'activity/actor/global');
+    console.log('Global actor activity done.');
+
+    // get chinese company activity
+    // by month
+    const chineseCompanyMonthActivityData = await getRepoActivityWithDetail({
+      labelIntersect: ['Company', ':regions/China'],
+      startYear, startMonth, endYear, endMonth,
+      order: 'DESC', limit: -1, percision: 2,
+      groupBy: 'Company',
+      groupTimeRange: 'month',
+    });
+    const chineseCompanyMonthActivityMap = rankData(chineseCompanyMonthActivityData!, allMonthes, (item, _, index) => item.activity[index], (item, index) => {
+      return {
+        name: item.name,
+        ...item.details[index],
+      }
+    });
+    for (const k of chineseCompanyMonthActivityMap.keys()) {
+      chineseCompanyMonthActivityMap.set(k, chineseCompanyMonthActivityMap.get(k)!.filter(i => i.value > 0));
+    }
+    writeData(chineseCompanyMonthActivityMap, 'Company_China_Month', 'activity/company/chinese');
+    
+    // by year
+    const chineseCompanyYearActivityData = await getRepoActivityWithDetail({
+      labelIntersect: ['Company', ':regions/China'],
+      startYear, startMonth, endYear, endMonth,
+      order: 'DESC', limit: -1, percision: 2,
+      groupBy: 'Company',
+      groupTimeRange: 'year',
+    });
+    const chineseCompanyYearActivityMap = rankData(chineseCompanyYearActivityData!, allYears, (item, _, index) => item.activity[index], (item, index) => {
+      return {
+        name: item.name,
+        ...item.details[index],
+      }
+    });
+    for (const k of chineseCompanyYearActivityMap.keys()) {
+      chineseCompanyYearActivityMap.set(k, chineseCompanyYearActivityMap.get(k)!.filter(i => i.value > 0));
+    }
+    writeData(chineseCompanyYearActivityMap, 'Repo_China_Year', 'activity/company/chinese');
+    console.log('Chinese company activity done.');
+
+    // get global company activity
+    // by month
+    const globalCompanyMonthActivityData = await getRepoActivityWithDetail({
+      labelUnion: ['Company'],
+      startYear, startMonth, endYear, endMonth,
+      order: 'DESC', limit: -1, percision: 2,
+      groupBy: 'Company',
+      groupTimeRange: 'month',
+    });
+    const globalCompanyMonthActivityMap = rankData(globalCompanyMonthActivityData!, allMonthes, (item, _, index) => item.activity[index], (item, index) => {
+      return {
+        name: item.name,
+        ...item.details[index],
+      }
+    });
+    for (const k of globalCompanyMonthActivityMap.keys()) {
+      globalCompanyMonthActivityMap.set(k, globalCompanyMonthActivityMap.get(k)!.filter(i => i.value > 0));
+    }
+    writeData(globalCompanyMonthActivityMap, 'Company_Global_Month', 'activity/company/global');
+    
+    // by year
+    const globalCompanyYearActivityData = await getRepoActivityWithDetail({
+      labelUnion: ['Company'],
+      startYear, startMonth, endYear, endMonth,
+      order: 'DESC', limit: -1, percision: 2,
+      groupBy: 'Company',
+      groupTimeRange: 'year',
+    });
+    const globalCompanyYearActivityMap = rankData(globalCompanyYearActivityData!, allYears, (item, _, index) => item.activity[index], (item, index) => {
+      return {
+        name: item.name,
+        ...item.details[index],
+      }
+    });
+    for (const k of globalCompanyYearActivityMap.keys()) {
+      globalCompanyYearActivityMap.set(k, globalCompanyYearActivityMap.get(k)!.filter(i => i.value > 0));
+    }
+    writeData(globalCompanyYearActivityMap, 'Repo_Global_Year', 'activity/company/global');
+    console.log('Global company activity done.');
+
+    // get global repo activity
+    // by month
+    const globalRepoMonthActivityData = await getRepoActivityWithDetail({
+      startYear, startMonth, endYear, endMonth,
+      order: 'DESC', limit, percision: 2,
+      groupTimeRange: 'month',
+    });
+    const globalRepoMonthActivityMap = rankData(globalRepoMonthActivityData!, allMonthes, (item, _, index) => item.activity[index], (item, index) => {
+      return {
+        name: item.name,
+        ...item.details[index],
+      }
+    });
+    for (const k of globalRepoMonthActivityMap.keys()) {
+      globalRepoMonthActivityMap.set(k, globalRepoMonthActivityMap.get(k)!.filter(i => i.value > 0));
+    }
+    writeData(globalRepoMonthActivityMap, 'Repo_Global_Month', 'activity/repo/global');
+    // by year
+    const globalRepoYearActivityData = await getRepoActivityWithDetail({
+      startYear, startMonth, endYear, endMonth,
+      order: 'DESC', limit, percision: 2,
+      groupTimeRange: 'year',
+    });
+    const globalRepoYearActivityMap = rankData(globalRepoYearActivityData!, allYears, (item, _, index) => item.activity[index], (item, index) => {
+      return {
+        name: item.name,
+        ...item.details[index],
+      }
+    });
+    for (const k of globalRepoYearActivityMap.keys()) {
+      globalRepoYearActivityMap.set(k, globalRepoYearActivityMap.get(k)!.filter(i => i.value > 0));
+    }
+    writeData(globalRepoYearActivityMap, 'Repo_Global_Year', 'activity/repo/global');
+    console.log('Global repo activity done.');
+
+    // get Chinese repo activity
+    // by month
+    const chineseRepoMonthActivityData = await getRepoActivityWithDetail({
+      labelUnion: [':regions/China'],
+      startYear, startMonth, endYear, endMonth,
+      order: 'DESC', limit: -1, percision: 2,
+      groupTimeRange: 'month',
+    });
+    const chineseRepoMonthActivityMap = rankData(chineseRepoMonthActivityData!, allMonthes, (item, _, index) => item.activity[index], (item, index) => {
+      return {
+        name: item.name,
+        ...item.details[index],
+      }
+    });
+    for (const k of chineseRepoMonthActivityMap.keys()) {
+      chineseRepoMonthActivityMap.set(k, chineseRepoMonthActivityMap.get(k)!.filter(i => i.value > 0));
+    }
+    writeData(chineseRepoMonthActivityMap, 'Repo_China_Month', 'activity/repo/chinese');
+    // by year
+    const chineseRepoYearActivityData = await getRepoActivityWithDetail({
+      labelUnion: [':regions/China'],
+      startYear, startMonth, endYear, endMonth,
+      order: 'DESC', limit: -1, percision: 2,
+      groupTimeRange: 'year',
+    });
+    const chineseRepoYearActivityMap = rankData(chineseRepoYearActivityData!, allYears, (item, _, index) => item.activity[index], (item, index) => {
+      return {
+        name: item.name,
+        ...item.details[index],
+      }
+    });
+    for (const k of chineseRepoYearActivityMap.keys()) {
+      chineseRepoYearActivityMap.set(k, chineseRepoYearActivityMap.get(k)!.filter(i => i.value > 0));
+    }
+    writeData(chineseRepoYearActivityMap, 'Repo_China_Year', 'activity/repo/chinese');
+    console.log('Chinese repo activity done.');
+
+    const defaultReducer = (a: number, b: number) => a + b;
+    const openRankProp = (time: any) => `open_rank_${time}`;
+    const getOpenRank = (item: any, time: string) => item[openRankProp(time)] ?? 0;
+    const chineseLabel = getGitHubData([':regions/China']);
+    // get Chinese repo OpenRank
+    const chineseRepoData = await query(`MATCH (r:Repo) WHERE r.id IN [${chineseLabel.githubRepos.join(',')}] OR r.org_id IN [${chineseLabel.githubOrgs.join(',')}] RETURN r;`);
+    // by month
+    writeData(rankData(chineseRepoData, allMonthes, getOpenRank, item => item.name), 'Repo_China_Month', 'open_rank/repo/chinese');
+    // by year
+    writeData(rankData(chineseRepoData,
+      allYears, 
+      (item, year) => monthInAYear.map(m => getOpenRank(item, `${year}${m}`)).reduce(defaultReducer),
+      item => item.name), 'Repo_China_Year', 'open_rank/repo/chinese');
+    console.log('Chinese repo OpenRank done.');
+
+    // get Chinese actor OpenRank
+    const chineseActorData = await query(`MATCH (u:User) WHERE u.id IN [${chineseLabel.githubUsers.join(',')}] RETURN u;`);
+    // by month
+    writeData(rankData(chineseActorData, allMonthes, getOpenRank, item => item.login), 'Actor_China_Month', 'open_rank/actor/chinese');
+    // by year
+    writeData(rankData(chineseActorData,
+      allYears,
+      (item, year) => monthInAYear.map(m => getOpenRank(item, `${year}${m}`)).reduce(defaultReducer),
+      item => item.login), 'Actor_China_Year', 'open_rank/repo/chinese');
+    console.log('Chinese actor OpenRank done.');
+    
+    // get Chinese company
+    const chineseCompanyDataMap = new Map<string, any>();
+    const companyLabelArr = labelData.filter(l => l.type === 'Company');
+    chineseRepoData.forEach(r => {
+      const companyName = companyLabelArr.find(l => l.githubRepos.includes(r.id) || l.githubOrgs.includes(r.org_id))?.name;
+      if (!companyName) return; // not a company repo
+      if (!chineseCompanyDataMap.has(companyName)) chineseCompanyDataMap.set(companyName, {});
+      const companyInfo =chineseCompanyDataMap.get(companyName)!;
+      allMonthes.forEach(time => companyInfo[openRankProp(time)] = getOpenRank(companyInfo, time) + getOpenRank(r, time));
+      allYears.forEach(year => companyInfo[openRankProp(year)] = getOpenRank(companyInfo, year.toString()) + monthInAYear.map(m => getOpenRank(r, `${year}${m}`)).reduce(defaultReducer));
+    });
+    const chineseCompanyData = Array.from(chineseCompanyDataMap.entries()).map(v => {
+      return {
+        name: v[0],
+        ...v[1],
+      }
+    });
+    // by month
+    writeData(rankData(chineseCompanyData, allMonthes, getOpenRank, item => item.name), 'Company_China_Month', 'open_rank/company/chinese');
+    // by year
+    writeData(rankData(chineseCompanyData, allYears, getOpenRank, item => item.name), 'Company_China_Year', 'open_rank/company/chinese');
+    console.log('Chinese company OpenRank done.');
+
+    // get global repo OpenRank
+    const globalRepoDataMap = new Map<any, any>();
+    await forEveryMonth(startYear, startMonth, endYear, endMonth, async (y, m) => {
+      const globalMonthData = await query(`MATCH (r:Repo) WHERE r.${openRankProp(`${y}${m}`)} > 0 RETURN r ORDER BY r.${openRankProp(`${y}${m}`)} DESC LIMIT ${limit};`);
+      globalMonthData.forEach(r => globalRepoDataMap.set(r.id, r));
+    });
+    const globalRepoData = Array.from(globalRepoDataMap.values());
+    // by month
+    writeData(rankData(globalRepoData, allMonthes, getOpenRank, item => item.name), 'Repo_Global_Month', 'open_rank/repo/global');
+    // by year
+    writeData(rankData(globalRepoData,
+      allYears, 
+      (item, year) => monthInAYear.map(m => getOpenRank(item, `${year}${m}`)).reduce(defaultReducer),
+      item => item.name), 'Repo_Global_Year', 'open_rank/repo/global');
+    console.log('Global repo OpenRank done.');
+
+    // get global actor OpenRank
+    const globalActorDataMap = new Map<any, any>();
+    await forEveryMonth(startYear, startMonth, endYear, endMonth, async (y, m) => {
+      const globalMonthData = await query(`MATCH (u:User) WHERE u.${openRankProp(`${y}${m}`)} > 0 RETURN u ORDER BY u.${openRankProp(`${y}${m}`)} DESC LIMIT ${limit};`);
+      globalMonthData.forEach(r => globalActorDataMap.set(r.id, r));
+    });
+    const globalActorData = Array.from(globalActorDataMap.values());
+    // by month
+    writeData(rankData(globalActorData, allMonthes, getOpenRank, item => item.login), 'Actor_Global_Month', 'open_rank/actor/global');
+    // by year
+    writeData(rankData(globalActorData,
+      allYears, 
+      (item, year) => monthInAYear.map(m => getOpenRank(item, `${year}${m}`)).reduce(defaultReducer),
+      item => item.login), 'Actor_Global_Year', 'open_rank/actor/global');
+    console.log('Global actor OpenRank done.');
+
+    // get global company
+    const globalCompanyDataMap = new Map<string, any>();
+    const companyLabel = getGitHubData(['Company']);
+    const globalCompanyRepoData = await query(`MATCH (r:Repo) WHERE r.id IN [${companyLabel.githubRepos.join(',')}] OR r.org_id IN [${companyLabel.githubOrgs.join(',')}] RETURN r;`)
+    globalCompanyRepoData.forEach(r => {
+      const companyName = companyLabelArr.find(l => l.githubRepos.includes(r.id) || l.githubOrgs.includes(r.org_id))?.name;
+      if (!companyName) return; // not a company repo
+      if (!globalCompanyDataMap.has(companyName)) globalCompanyDataMap.set(companyName, {});
+      const companyInfo = globalCompanyDataMap.get(companyName)!;
+      allMonthes.forEach(time => companyInfo[openRankProp(time)] = getOpenRank(companyInfo, time) + getOpenRank(r, time));
+      allYears.forEach(year => companyInfo[openRankProp(year)] = getOpenRank(companyInfo, year.toString()) + monthInAYear.map(m => getOpenRank(r, `${year}${m}`)).reduce(defaultReducer));
+    });
+    const globalCompanyData = Array.from(globalCompanyDataMap.entries()).map(v => {
+      return {
+        name: v[0],
+        ...v[1],
+      }
+    });
+    // by month
+    writeData(rankData(globalCompanyData, allMonthes, getOpenRank, item => item.name), 'Company_Global_Month', 'open_rank/company/global');
+    // by year
+    writeData(rankData(globalCompanyData, allYears, getOpenRank, item => item.name), 'Company_Global_Year', 'open_rank/company/global');
+    console.log('Global company OpenRank done.');
+
+
+    writeFileSync('./local_files/open_index/meta.json', JSON.stringify({ lastUpdatedAt: new Date().getTime() }));
+    console.log('Task for open index done.');
+  }
+};
+
+module.exports = task;

--- a/src/metrics/activity_openrank.ts
+++ b/src/metrics/activity_openrank.ts
@@ -3,9 +3,13 @@ import { QueryConfig,
         getRepoWhereClauseForNeo4j, 
         getTimeRangeWhereClauseForNeo4j, 
         getTimeRangeSumClauseForNeo4j, 
-        getUserWhereClauseForNeo4j } from "./basic";
+        getUserWhereClauseForNeo4j, 
+        getRepoWhereClauseForClickhouse,
+        forEveryMonthByConfig,
+        getUserWhereClauseForClickhouse} from "./basic";
 import * as neo4j from '../db/neo4j'
 import { getLabelData } from "../label_data_utils";
+import * as clickhouse from "../db/clickhouse";
 
 export const getRepoActivityOrOpenrank = async (config: QueryConfig, type: 'activity' | 'open_rank') => {
   config = getMergedConfig(config);
@@ -56,4 +60,300 @@ export const getUserActivityOrOpenrank = (config: QueryConfig, type: 'activity' 
   const timeActivityClause = getTimeRangeSumClauseForNeo4j(config, `u.${type}`);
   const query = `MATCH (u:User) WHERE ${userWhereClause ? userWhereClause + ' AND ' : ''} ${timeWhereClause} RETURN u.login AS user_login, [${timeActivityClause.join(',')}] AS ${type} ORDER BY ${type} ${config.order} ${config.limit > 0 ? `LIMIT ${config.limit}` : ''};`;
   return neo4j.query(query);
+}
+
+export const getRepoActivityWithDetail = async (config: QueryConfig) => {
+  config = getMergedConfig(config);
+  const whereClauses: string[] = [];
+  const repoWhereClause = getRepoWhereClauseForClickhouse(config);
+  if (repoWhereClause) whereClauses.push(repoWhereClause);
+
+  const clickhouseActivityQuery = (year: number, whereClauses: string[], percision: number, order: string, limit: number) => {
+  return `SELECT repo_id AS id, anyHeavy(rname) AS name, anyHeavy(oid) AS org_id, anyHeavy(ologin) AS org_login, ROUND(SUM(activity),${percision}) AS activity, SUM(issue_comment) AS issue_comment, SUM(open_issue) AS open_issue, SUM(open_pull) AS open_pull, SUM(review_comment) AS review_comment, SUM(merged_pull) AS merged_pull FROM
+  (SELECT repo_id,
+    argMax(repo_name, created_at) AS rname,
+    argMax(org_id, created_at) AS oid,
+    argMax(org_login, created_at) AS ologin,
+    if(type='PullRequestEvent' AND action='closed' AND pull_merged=1, issue_author_id, actor_id) AS actor_id,
+    countIf(type='IssueCommentEvent' AND action='created') AS issue_comment,
+    countIf(type='IssuesEvent' AND action='opened')  AS open_issue,
+    countIf(type='PullRequestEvent' AND action='opened') AS open_pull,
+    countIf(type='PullRequestReviewCommentEvent' AND action='created') AS review_comment,
+    countIf(type='PullRequestEvent' AND action='closed' AND pull_merged=1) AS merged_pull,
+    sqrt(issue_comment + 2*open_issue + 3*open_pull + 4*review_comment + 2*merged_pull) AS activity
+  FROM github_log.year${year}
+${whereClauses.length > 0 ? 'WHERE ' + whereClauses.join(' AND ') : ''}
+GROUP BY repo_id, actor_id
+HAVING activity > 0)
+GROUP BY repo_id
+ORDER BY activity ${order}
+${limit > 0 ? `LIMIT ${limit}` : ''}`;
+};
+
+  let processCount = 0;
+  const resultMap = new Map<string, { id: number; name: string; org_id: number; org_login: string; activity: number[]; details: any[] }>();
+  const processRow = (row: any) => {
+    if (!resultMap.has(row.id)) {
+      resultMap.set(row.id, { id: row.id, name: row.name, org_id: row.org_id, org_login: row.org_login, activity: [], details: [] });
+      for (let i = 0; i < processCount; i++) {
+        resultMap.get(row.id)!.activity.push(0);
+        resultMap.get(row.id)!.details.push({
+          issue_comment: 0,
+          open_issue: 0,
+          open_pull: 0,
+          review_comment: 0,
+          merged_pull: 0,
+        });
+      }
+    }
+    resultMap.get(row.id)!.activity.push(row.activity);
+    resultMap.get(row.id)!.details.push({
+      issue_comment: row.issue_comment,
+      open_issue: row.open_issue,
+      open_pull: row.open_pull,
+      review_comment: row.review_comment,
+      merged_pull: row.merged_pull,
+    });
+  };
+  const fillResultMap = () => {
+    for (const v of resultMap.values()) {
+      while (v.activity.length < processCount) {
+        v.activity.push(0);
+        v.details.push({
+          issue_comment:  0,
+          open_issue: 0,
+          open_pull: 0,
+          review_comment: 0,
+          merged_pull: 0,
+        });
+      }
+    }
+  };
+
+  // handle the groupTimeRange config
+  // monthly
+  if (config.groupTimeRange == 'month') {
+    await forEveryMonthByConfig(config, async (y, m) => {
+      const q = clickhouseActivityQuery(y, [...whereClauses, `toMonth(created_at)=${m}`], config.percision, config.order, config.limit);
+      const monthResult = await clickhouse.query<any[]>(q);
+      monthResult.forEach(processRow);
+      processCount++;
+      fillResultMap();
+    });
+  }
+
+  // yearly
+  if (config.groupTimeRange == 'year') {
+    for (let year = config.startYear; year <= config.endYear; year++) {
+      let monthWhereClause: string = '';
+      if (year === config.startYear) {
+        monthWhereClause = `toMonth(created_at) >= ${config.startMonth}`;
+      } else if (year === config.endYear) {
+        monthWhereClause = `toMonth(created_at) <= ${config.endMonth}`;
+      }
+      const q = clickhouseActivityQuery(year, [...whereClauses, monthWhereClause].filter(i => i !== ''), config.percision, config.order, config.limit);
+      const yearResult = await clickhouse.query<any[]>(q);
+      yearResult.forEach(processRow);
+      processCount++;
+      fillResultMap();
+    }
+  }
+
+  // quarterly
+  if (config.groupTimeRange == 'quarter') {
+    for (let year = config.startYear; year <= config.endYear; year++) {
+      for (let quarter = 1; quarter <= 4; quarter++) {
+        let quarterWhereClause: string = '';
+        if (year === config.startYear) {
+          quarterWhereClause = `toQuarter(created_at) = ${quarter} AND toMonth(created_at) >= ${config.startMonth}`;
+        } else if (year === config.endYear) {
+          quarterWhereClause = `toQuarter(created_at) = ${quarter} AND toMonth(created_at) <= ${config.endMonth}`;
+        }
+        const q = clickhouseActivityQuery(year, [...whereClauses, quarterWhereClause].filter(i => i !== ''), config.percision, config.order, config.limit);
+        const quarterResult = await clickhouse.query<any[]>(q);
+        quarterResult.forEach(processRow);
+        processCount++;
+        fillResultMap();
+      }
+    }
+  }
+
+  // handle the groupBy config
+  const addValues = (a, b) => {
+    return {
+      activity: a.activity.map((v, i) => parseFloat((v + b.activity[i]).toFixed(config.percision))),
+      details: a.details.map((v, i) => {
+        return {
+          issue_comment: parseInt(v.issue_comment) + parseInt(b.details[i].issue_comment),
+          open_issue: parseInt(v.open_issue) + parseInt(b.details[i].open_issue),
+          open_pull: parseInt(v.open_pull) + parseInt(b.details[i].open_pull),
+          review_comment: parseInt(v.review_comment) + parseInt(b.details[i].review_comment),
+          merged_pull: parseInt(v.merged_pull) + parseInt(b.details[i].merged_pull),
+        };
+      }),
+    }
+  };
+  if (!config.groupBy) {    // group by repo
+    const result = Array.from(resultMap.values()).sort((a, b) => b.activity[b.activity.length - 1] - a.activity[a.activity.length - 1]);
+    return result;
+  } else if (config.groupBy === 'org') {    // group by org
+    const orgMap = new Map<string, { activity: number[]; details: any[] }>();
+    for (const v of resultMap.values()) {
+      if (!orgMap.has(v.org_login)) orgMap.set(v.org_login, { activity: [0], details: [{
+        issue_comment: 0,
+        open_issue: 0,
+        open_pull: 0,
+        review_comment: 0,
+        merged_pull: 0,
+      }]});
+      orgMap.set(v.org_login, addValues(orgMap.get(v.org_login)!, v)!);
+    }
+    const result = Array.from(orgMap.entries()).map(i => {
+      return {
+        name: i[0],
+        ...i[1],
+      }
+    }).sort((a, b) => b.activity[b.activity.length - 1] - a.activity[a.activity.length - 1]);
+    return result;
+  } else {    // group by label
+    const labelData = getLabelData()?.filter(l => l.type === config.groupBy);
+    if (!labelData || labelData.length === 0) return null;
+    const labelMap = new Map<string, { activity: number[]; details: any[] }>();
+    for (const v of resultMap.values()) {
+      const label = labelData.find(l => l.githubRepos.includes(parseInt(v.id.toString())) || l.githubOrgs.includes(parseInt(v.org_id.toString())))?.name;
+      if (!label) {
+        console.log(`Not found label for ${v.id}`);
+        continue;
+      }
+      if (!labelMap.has(label)) labelMap.set(label, {
+        activity: v.activity,
+        details: v.details,
+      });
+      else labelMap.set(label, addValues(labelMap.get(label)!, v)!);
+    }
+    const result = Array.from(labelMap.entries()).map(i => {
+      return {
+        name: i[0],
+        ...i[1],
+      }
+    }).sort((a, b) => b.activity[b.activity.length - 1] - a.activity[a.activity.length - 1]);
+    return result;
+  }
+}
+
+export const getUserActivityWithDetail = async (config: QueryConfig) => {
+  config = getMergedConfig(config);
+  const whereClauses: string[] = [];
+  const userWhereClause = getUserWhereClauseForClickhouse(config);
+  if (userWhereClause) whereClauses.push(userWhereClause);
+
+  const clickhouseActivityQuery = (year: number, whereClauses: string[], percision: number, order: string, limit: number) => {
+  return `SELECT actor_id AS id, anyHeavy(actor_login) AS login, ROUND(SUM(activity),${percision}) AS activity, SUM(issue_comment) AS issue_comment, SUM(open_issue) AS open_issue, SUM(open_pull) AS open_pull, SUM(review_comment) AS review_comment, SUM(merged_pull) AS merged_pull FROM
+  (SELECT repo_id,
+    if(type='PullRequestEvent' AND action='closed' AND pull_merged=1, issue_author_id, actor_id) AS actor_id,
+    argMax(if(type= 'PullRequestEvent' AND action= 'closed' AND pull_merged= 1, issue_author_login, actor_login), created_at) AS actor_login,
+    countIf(type='IssueCommentEvent' AND action='created') AS issue_comment,
+    countIf(type='IssuesEvent' AND action='opened')  AS open_issue,
+    countIf(type='PullRequestEvent' AND action='opened') AS open_pull,
+    countIf(type='PullRequestReviewCommentEvent' AND action='created') AS review_comment,
+    countIf(type='PullRequestEvent' AND action='closed' AND pull_merged=1) AS merged_pull,
+    sqrt(issue_comment + 2*open_issue + 3*open_pull + 4*review_comment + 2*merged_pull) AS activity
+  FROM github_log.year${year}
+${whereClauses.length > 0 ? 'WHERE ' + whereClauses.join(' AND ') : ''}
+GROUP BY repo_id, actor_id
+HAVING activity > 0)
+GROUP BY actor_id
+ORDER BY activity ${order}
+${limit > 0 ? `LIMIT ${limit}` : ''}`;
+};
+  let processCount = 0;
+  const resultMap = new Map<string, { id: number; login: string; activity: number[]; details: any[] }>();
+  const processRow = (row: any) => {
+    if (!resultMap.has(row.id)) {
+      resultMap.set(row.id, { id: row.id, login: row.login, activity: [], details: [] });
+      for (let i = 0; i < processCount; i++) {
+        resultMap.get(row.id)!.activity.push(0);
+        resultMap.get(row.id)!.details.push({
+          issue_comment: 0,
+          open_issue: 0,
+          open_pull: 0,
+          review_comment: 0,
+          merged_pull: 0,
+        });
+      }
+    }
+    resultMap.get(row.id)!.activity.push(row.activity);
+    resultMap.get(row.id)!.details.push({
+      issue_comment: row.issue_comment,
+      open_issue: row.open_issue,
+      open_pull: row.open_pull,
+      review_comment: row.review_comment,
+      merged_pull: row.merged_pull,
+    });
+  };
+  const fillResultMap = () => {
+    for (const v of resultMap.values()) {
+      while (v.activity.length < processCount) {
+        v.activity.push(0);
+        v.details.push({
+          issue_comment:  0,
+          open_issue: 0,
+          open_pull: 0,
+          review_comment: 0,
+          merged_pull: 0,
+        });
+      }
+    }
+  };
+
+  // handle the groupTimeRange config
+  // monthly
+  if (config.groupTimeRange == 'month') {
+    await forEveryMonthByConfig(config, async (y, m) => {
+      const q = clickhouseActivityQuery(y, [...whereClauses, `toMonth(created_at)=${m}`], config.percision, config.order, config.limit);
+      const monthResult = await clickhouse.query<any[]>(q);
+      monthResult.forEach(processRow);
+      processCount++;
+      fillResultMap();
+    });
+  }
+
+  // yearly
+  if (config.groupTimeRange == 'year') {
+    for (let year = config.startYear; year <= config.endYear; year++) {
+      let monthWhereClause: string = '';
+      if (year === config.startYear) {
+        monthWhereClause = `toMonth(created_at) >= ${config.startMonth}`;
+      } else if (year === config.endYear) {
+        monthWhereClause = `toMonth(created_at) <= ${config.endMonth}`;
+      }
+      const q = clickhouseActivityQuery(year, [...whereClauses, monthWhereClause].filter(i => i !== ''), config.percision, config.order, config.limit);
+      const yearResult = await clickhouse.query<any[]>(q);
+      yearResult.forEach(processRow);
+      processCount++;
+      fillResultMap();
+    }
+  }
+
+  // quarterly
+  if (config.groupTimeRange == 'quarter') {
+    for (let year = config.startYear; year <= config.endYear; year++) {
+      for (let quarter = 1; quarter <= 4; quarter++) {
+        let quarterWhereClause: string = '';
+        if (year === config.startYear) {
+          quarterWhereClause = `toQuarter(created_at) = ${quarter} AND toMonth(created_at) >= ${config.startMonth}`;
+        } else if (year === config.endYear) {
+          quarterWhereClause = `toQuarter(created_at) = ${quarter} AND toMonth(created_at) <= ${config.endMonth}`;
+        }
+        const q = clickhouseActivityQuery(year, [...whereClauses, quarterWhereClause].filter(i => i !== ''), config.percision, config.order, config.limit);
+        const quarterResult = await clickhouse.query<any[]>(q);
+        quarterResult.forEach(processRow);
+        processCount++;
+        fillResultMap();
+      }
+    }
+  }
+
+  const result = Array.from(resultMap.values()).sort((a, b) => b.activity[b.activity.length - 1] - a.activity[a.activity.length - 1]);
+  return result;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -39,3 +39,38 @@ export async function waitUntil(func: () => boolean, options?: object): Promise<
   if (func()) return;
   return pWaitFor(func, Object.assign({ interval: 1000 }, options));
 }
+
+interface rankDataResultItem<T> { 
+  item: T;
+  rank: number;
+  value: number;
+  rankDelta: number;
+  valueDelta: number;
+};
+export function rankData<T = any>(data: T[], iterArr: any[], getter: (item: T, iterItem: any, iterIndex: number) => number, itemIdentifiterGetter: (item: T, iterIndex: number) => any): Map<any, rankDataResultItem<T>[]> {
+  const result = new Map<any, rankDataResultItem<T>[]>();
+  const lastRankMap = new Map<any, { rank: number; value: number; }>();
+  data.forEach(i => lastRankMap.set(i, { rank: -1, value: 0 }));
+  for (let iterIndex = 0; iterIndex < iterArr.length; iterIndex++) {
+    const iterItem = iterArr[iterIndex];
+    const iterResult: any[] = [];
+    data = data.sort((a, b) => (getter(b, iterItem, iterIndex) ?? 0) - (getter(a, iterItem, iterIndex) ?? 0));
+    data.forEach((i: any, index) => {
+      const rank = getter(i, iterItem, iterIndex) ? index + 1 : -1;
+      const value = parseFloat((getter(i, iterItem, iterIndex) ?? 0).toFixed(2));
+      const lastRank = lastRankMap.get(i)!;
+      lastRankMap.set(i, { rank, value });
+
+      if (rank === -1) return;
+      iterResult.push({
+        item: itemIdentifiterGetter(i, iterIndex),
+        rank,
+        value,
+        rankDelta: lastRank.rank === -1 ? 0 : lastRank.rank - rank,
+        valueDelta: parseFloat((value - lastRank.value).toFixed(2)),
+      });
+    });
+    result.set(iterItem, iterResult);
+  }
+  return result;
+}


### PR DESCRIPTION
Signed-off-by: Frankzhaopku <syzhao1988@126.com>

Add a cron task for open leaderboard and as well as some minor fix:

- Add Ant Group and Fit2Cloud into Chinese label.
- Change `forEveryMonth` to support async function.
- Add clickhouse version activity query.
- Change `season` to `quarter`.