### PR TITLE
fix: hypertrons update contribution config

### DIFF
--- a/.github/hypertrons-components/auto_update_contribution/defaultConfig.ts
+++ b/.github/hypertrons-components/auto_update_contribution/defaultConfig.ts
@@ -16,10 +16,9 @@ import Config from './config';
 
 const defaultConfig: Config = {
   schedName: 'Auto update contribution',
-  sched: '0 0 22 * * *',
+  sched: '0 0 12 * * 1',
   roles: [
     'committer',
-    'sql-reviewer',
     'replier',
     'contributor',
     'participant',


### PR DESCRIPTION
Signed-off-by: Frankzhaopku <syzhao1988@126.com>

Fix Hypertrons config for update contribution since we do not have `sql-reviewer` role any more and change the update time to 12 o'clock every Monday.