### PR TITLE
[Data] Add my id as X-lab members labeled data into OpenDigger

### DIFF
--- a/labeled_data/communities/xlab/index.yml
+++ b/labeled_data/communities/xlab/index.yml
@@ -22,3 +22,4 @@ data:
     - 20661689 # soobun 苏斌
     - 2922845  # chunchill 邱娟
     - 61407528 # wengzhenjie 翁振杰
+    - 29705275 # yoyo-wu98 吴双


### PR DESCRIPTION
According to the issue comment https://github.com/X-lab2017/open-digger/issues/864#issuecomment-1171267350 , I want to add my id as X-lab members labeled data into OpenDigger.

**But my account name has been changed so my `actor_login` can also be '1054096100'. 
Should I mention it in the code comments?**

```sql
SELECT actor_login, COUNT() as name_sum
FROM github_log.events where actor_id='29705275'
GROUP BY actor_login

[Out]
  actor_login  name_sum
0  1054096100       851
1   yoyo-wu98        21
```
So both `actor_login` have its own events.

 Sorry if it makes something difficult:(