### PR TITLE
[Doc] Correct an example command line and change some context order of the sample_data/README

### DIFF
--- a/sample_data/README.md
+++ b/sample_data/README.md
@@ -14,15 +14,22 @@ We can use ClickHouse online service with full data access to make ClikcHouse sa
 To use sample data from OSS service, you need to follow the steps:
 
 1. Download data from OSS. We provide several sample datasets in the table below. 
+
 2. Extract data from archive file to a folder: `tar -zxvf data.tar.gz -C ./folder_name`. You will get a `table` and a `data` file.
+
 3. Use ClickHouse base image with extracted data to initialize the database. The extracted `data` and `table` file should be mounted into `/data/` folder into the container, here is an example:
    - Linux: `docker run -d --name container_name -m 6G -p 8123:8123 -p 9000:9000 --ulimit nofile=262144:262144 --volume=$(pwd)/folder_name/:/data/ open-digger-clickhouse-base:v1`;
    - Windows: `docker run -d --name container_name -m 6G -p 8123:8123 -p 9000:9000 --ulimit nofile=262144:262144 --volume=%cd%/folder_name/:/data/ open-digger-clickhouse-base:v1`.
+   
+   In the above command lines, `$(pwd)` or `%cd%` makes sure the `host-src` be an absolute path.
    > **Notice**: As referred in [Docker's Doc](https://docs.docker.com/engine/reference/run/#volume-shared-filesystems), the `host-src` in `--volume=[host-src:]container-dest[:<options>]` must be an absolute path or a name value.
+   >
    > - If you supply an absolute path for the `host-src`, Docker bind-mounts to the path you specify. 
+   >
    > - If you supply a name, Docker creates a named volume by that name.
    >
    > **A name value must start with an alphanumeric character, followed by `a-z0-9`, `_` (underscore), `.` (period) or `-` (hyphen). An absolute path starts with a `/` (forward slash).**
+
 4. The data is ready until message `Insert data done.` logged into container console. Now the Clickhouse container is running. Stop and restart the same container instance will not import data again.
 
 To use the sample data, at minimum 8 GB memory should be allocated to the container instance.
@@ -59,7 +66,7 @@ Start your ClickHouse container, which should be set up in the last step. Now:
    }
    ```
 
-5. Use `npm run notebook` to use Notebook image if you use Linux/MacOS system, or to use `npm run notebook:win ` if you use Windows system.
+5. Use `npm run notebook` to use Notebook image if you use Linux/MacOS system, or to use `npm run notebook:win` if you use Windows system.
 
 6. Open the link in console log like `http://127.0.0.1:8888/lab?token=xxxxx`.
 

--- a/sample_data/README.md
+++ b/sample_data/README.md
@@ -4,14 +4,26 @@ We can use ClickHouse online service with full data access to make ClikcHouse sa
 
 ## Usage
 
+### ClickHouse server image
+
+- x86: `docker pull docker-hub.x-lab.info/opendigger/open-digger-clickhouse-base:v1`
+- ARM: `docker pull docker-hub.x-lab.info/opendigger/open-digger-clickhouse-base-arm:v1`
+
 ### Use sample data
 
 To use sample data from OSS service, you need to follow the steps:
 
-- Download data from OSS. We provide several sample datasets in the table below. 
-- Extract data from archive file to a folder: `tar -zxvf data.tar.gz -C ./folder_path`. You will get a `table` and a `data` file.
-- Use ClickHouse base image with extracted data to initialize the database. The extracted `data` and `table` file should be mounted into `/data/` folder into the container, here is an example: `docker run -d --name container_name -m 6G -p 8123:8123 -p 9000:9000 --ulimit nofile=262144:262144 --volume=./folder_path/:/data/ open-digger-clickhouse-base:v1`
-- The data is ready until message `Insert data done.` logged into container console. Now the Clickhouse container is running. Stop and restart the same container instance will not import data again.
+1. Download data from OSS. We provide several sample datasets in the table below. 
+2. Extract data from archive file to a folder: `tar -zxvf data.tar.gz -C ./folder_name`. You will get a `table` and a `data` file.
+3. Use ClickHouse base image with extracted data to initialize the database. The extracted `data` and `table` file should be mounted into `/data/` folder into the container, here is an example:
+   - Linux: `docker run -d --name container_name -m 6G -p 8123:8123 -p 9000:9000 --ulimit nofile=262144:262144 --volume=$(pwd)/folder_name/:/data/ open-digger-clickhouse-base:v1`;
+   - Windows: `docker run -d --name container_name -m 6G -p 8123:8123 -p 9000:9000 --ulimit nofile=262144:262144 --volume=%cd%/folder_name/:/data/ open-digger-clickhouse-base:v1`.
+   > **Notice**: As referred in [Docker's Doc](https://docs.docker.com/engine/reference/run/#volume-shared-filesystems), the `host-src` in `--volume=[host-src:]container-dest[:<options>]` must be an absolute path or a name value.
+   > - If you supply an absolute path for the `host-src`, Docker bind-mounts to the path you specify. 
+   > - If you supply a name, Docker creates a named volume by that name.
+   >
+   > **A name value must start with an alphanumeric character, followed by `a-z0-9`, `_` (underscore), `.` (period) or `-` (hyphen). An absolute path starts with a `/` (forward slash).**
+4. The data is ready until message `Insert data done.` logged into container console. Now the Clickhouse container is running. Stop and restart the same container instance will not import data again.
 
 To use the sample data, at minimum 8 GB memory should be allocated to the container instance.
 
@@ -24,11 +36,6 @@ To use the sample data, at minimum 8 GB memory should be allocated to the contai
 | [second_sample](https://oss.x-lab.info/sample_data/second_sample.tar.gz) | All events log sample by 1 second in a hour | sql_files/second_sample.sql | 62 million | 57 GB | 10 GB | 14 GB | 25 m |
 | [label_2015](https://oss.x-lab.info/sample_data/label_2015.tar.gz) | All events log for labeled repo in OpenDigger in 2015 | sql_files/label_2015.sql | 3.5 million | 2.9 GB | 378 MB | 552 MB | 3 m |
 | [paddle_hackathon_3](https://oss.x-lab.info/sample_data/paddle_hackathon_3.tar.gz) | Data under PaddlePaddle org for Hackathon | sql_files/paddle_hackathon_3.sql | 803 thousands | 736 MB | 96 MB | 141 MB | 1 m |
-
-### ClickHouse server image
-
-- x86: `docker pull docker-hub.x-lab.info/opendigger/open-digger-clickhouse-base:v1`
-- ARM: `docker pull docker-hub.x-lab.info/opendigger/open-digger-clickhouse-base-arm:v1`
 
 ### Use Notebook image
 

--- a/sample_data/README.md
+++ b/sample_data/README.md
@@ -18,7 +18,7 @@ To use sample data from OSS service, you need to follow the steps:
 2. Extract data from archive file to a folder: `tar -zxvf data.tar.gz -C ./folder_name`. You will get a `table` and a `data` file.
 
 3. Use ClickHouse base image with extracted data to initialize the database. The extracted `data` and `table` file should be mounted into `/data/` folder into the container, here is an example:
-   - Linux: `docker run -d --name container_name -m 6G -p 8123:8123 -p 9000:9000 --ulimit nofile=262144:262144 --volume=$(pwd)/folder_name/:/data/ open-digger-clickhouse-base:v1`;
+   - Linux/MacOS: `docker run -d --name container_name -m 6G -p 8123:8123 -p 9000:9000 --ulimit nofile=262144:262144 --volume=$(pwd)/folder_name/:/data/ open-digger-clickhouse-base:v1`;
    - Windows: `docker run -d --name container_name -m 6G -p 8123:8123 -p 9000:9000 --ulimit nofile=262144:262144 --volume=%cd%/folder_name/:/data/ open-digger-clickhouse-base:v1`.
    
    In the above command lines, `$(pwd)` or `%cd%` makes sure the `host-src` be an absolute path.

--- a/sample_data/start_server.sh
+++ b/sample_data/start_server.sh
@@ -1,1 +1,1 @@
-docker run -d --name 2020_full_ch_server -p 8123:8123 -p 9000:9000 --ulimit nofile=262144:262144 --volume=./data/2020_full/:/data/ open-digger-clickhouse-base:v1
+docker run -d --name 2020_full_ch_server -p 8123:8123 -p 9000:9000 --ulimit nofile=262144:262144 --volume=$(pwd)/data/2020_full/:/data/ open-digger-clickhouse-base:v1


### PR DESCRIPTION
### Description

According to the discussion in issue #917 , an example command line in sample_data/README.md should be corrected to avoid a bug.

As @frank-zsy mentioned in https://github.com/X-lab2017/open-digger/issues/917#issuecomment-1190953277 :

> I think we can use $(pwd) before the folder name to complete the path, which will lead another thing that under windows, this should be replaced by %cd%. This will give the command an absolute path of the folder.

### Changes

So, the changes in this PR are:

1 .We correct the command line and add a notice right after it.
2. To make the guide more easy to follow, I change some context order of the doc to make the instructions sequential.