### PR TITLE
Feat: Implementing Issue Age Metric

### DIFF
--- a/src/metrics/chaoss.ts
+++ b/src/metrics/chaoss.ts
@@ -383,8 +383,8 @@ SELECT
 FROM
 (
   SELECT
-    ${getGroupTimeAndIdClauseForClickhouse(config, 'repo')},
-    round(${type}(dateDiff('${unit}', opened_at, '${endDate.getFullYear()}-${endDate.getMonth()+1}-1')),${config.percision}) AS issue_age
+    ${getGroupTimeAndIdClauseForClickhouse(config, 'repo','opened_at')},
+    round(${type}(dateDiff('${unit}', opened_at, toDate('${endDate.getFullYear()}-${endDate.getMonth()+1}'))),${config.percision}) AS issue_age
   FROM
   (
     SELECT

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -1,5 +1,5 @@
 import { getRepoActivityOrOpenrank, getRepoActivityWithDetail, getUserActivityOrOpenrank, getUserActivityWithDetail } from './activity_openrank';
-import { chaossCodeChangeCommits, chaossBusFactor, chaossIssuesNew, chaossIssuesClosed, chaossChangeRequestsAccepted, chaossChangeRequestsDeclined, chaossIssueResolutionDuration } from './chaoss';
+import { chaossCodeChangeCommits, chaossBusFactor, chaossIssuesNew, chaossIssuesClosed, chaossChangeRequestsAccepted, chaossChangeRequestsDeclined, chaossIssueResolutionDuration, chaossIssueAge } from './chaoss';
 import { getAttention } from './attention';
 import { getRelatedUsers } from './related_users';
 
@@ -21,4 +21,5 @@ module.exports = {
   chaossChangeRequestsAccepted: chaossChangeRequestsAccepted,
   chaossChangeRequestsDeclined: chaossChangeRequestsDeclined,
   chaossIssueResolutionDuration: chaossIssueResolutionDuration,
+  chaossIssueAge: chaossIssueAge,
 }

--- a/src/open_digger.js
+++ b/src/open_digger.js
@@ -37,6 +37,7 @@ const openDigger = {
       changeRequestsAccepted: func.chaossChangeRequestsAccepted,
       changeRequestsDeclined: func.chaossChangeRequestsDeclined,
       chaossIssueResolutionDuration: func.chaossIssueResolutionDuration,
+      chaossIssueAge: func.chaossIssueAge,
     }
   },
   relation: {


### PR DESCRIPTION
I'm implementing metric #588 and running into some issues.

The error message is :

`Error: Missing columns: 'created_at' while processing query: 'SELECT toStartOfMonth(created_at) AS time, arrayJoin(multiIf((org_id IN (476009, 2976699, 3536625, 4542585, 4175954, 2718604, 4028872, 32504, 4764587, 5420974, 1440554)) OR (repo_id IN (6898381, 6898387, 5611582)), ['Adobe']......GROUP BY repo_id, org_id, issue_number HAVING (opened_at < toDate('2016-1-1')) AND ((last_action = 'opened') OR (last_action = 'reopened'))) GROUP BY id, time ORDER BY issue_age DESC LIMIT 10 BY time', required columns: 'org_id' 'repo_id' 'opened_at' 'created_at', source columns: 'last_action' 'org_login' 'issue_number' 'opened_at' 'org_id' 'repo_name' 'repo_id'`