### PR TITLE
[Doc] Add python kernel sample data guide.

### DIFF
--- a/sample_data/README.md
+++ b/sample_data/README.md
@@ -46,6 +46,8 @@ To use the sample data, at minimum 8 GB memory should be allocated to the contai
 
 ### Use Notebook image
 
+#### Node.js Version
+
 Start your ClickHouse container, which should be set up in the last step. Now:
 
 1. Clone OpenDigger `git clone https://github.com/X-lab2017/open-digger.git`
@@ -71,6 +73,53 @@ Start your ClickHouse container, which should be set up in the last step. Now:
 6. Open the link in console log like `http://127.0.0.1:8888/lab?token=xxxxx`.
 
 7. If the source code under `src` folder changed, you need to use `npm run build` and restart the notebook kernel to reload the sorce code.
+
+8. You can find the notebook folder, where we provide demos in the handbook. You can create a new file, and happy data exploring!
+
+#### Python Version
+
+Start your ClickHouse container, which should be set up in the last step. Now:
+
+1. Clone OpenDigger `git clone https://github.com/X-lab2017/open-digger.git`
+
+2. Enter the repo path `cd open-digger`
+
+3. Go to the `src` folder in the open-digger root directory, create a file named 'local_config.py' for Python Kernel with the following contents:
+
+   ```python
+   local_config = {
+     'db': {
+       'clickhouse': {
+         'host':'172.17.0.1', 
+         'user':'default'
+       },
+       'neo4j':{
+         'port': '7687',
+       }
+     }
+   }
+   ```
+   the `host` above is the host of the ClickHouse server. We can find it using `docker inspect containert_name`, and copy the `Gateway` like this:
+
+   ```shell
+   $ docker inspect container_name | grep Gateway
+               "Gateway": "172.17.0.1",
+               "IPv6Gateway": "",
+                       "Gateway": "172.17.0.1",
+                       "IPv6Gateway": "",
+   ```
+
+4. Use `docker build -t opendigger-jupyter-python:1.0 $(pwd)` to make a docker image, this image is based on `miniconda`. You can check the `Dockerfile` in root directory.
+
+   > If you are using **Windows CMD**, all the `$(pwd)` here should be replaced by `%cd%`. And if you are using **Windows Powershell**,  all the `$(pwd)` here should be replaced by `${pwd}`.
+   >
+   > **Notice:** Pathnames of directories like "pwd" may use `\` to join the directory in some versions of Windows. We recommend using absolute paths.
+
+5. Then we can use `docker run -it --name python_notebook_name --rm -p 8888:8888 -v $(pwd):/python_kernel/notebook opendigger-jupyter-python:1.0` to create and run the container.
+
+6. Open the link in console log like `http://127.0.0.1:8888/lab?token=xxxxx`.
+
+7. If the source code under `src` folder changed, you need to stop the notebook docker using `docker stop python_notebook_name` and restart the notebook kernel using `docker run -it --name python_notebook_name --rm -p 8888:8888 -v $(pwd):/python_kernel/notebook opendigger-jupyter-python:1.0` to reload the sorce code.
 
 8. You can find the notebook folder, where we provide demos in the handbook. You can create a new file, and happy data exploring!
 


### PR DESCRIPTION
Since we have added the Python Kernel of the open-digger and there is an issue #968 asking for it, the guide of the Sample Data Usage with Python Kernel should be added.