### PR TITLE
Filter opendigger-bot's comment

### DIFF
--- a/.github/workflows/reply-label-issue-comment.yml
+++ b/.github/workflows/reply-label-issue-comment.yml
@@ -25,7 +25,7 @@ jobs:
 
   add-label-if-not-author:
     runs-on: ubuntu-latest
-    if: (github.event.issue.user.id != github.event.comment.user.id && user.id != 69946302) && !github.event.issue.pull_request && (github.event.issue.state == 'open')
+    if: (github.event.issue.user.id != github.event.comment.user.id && github.event.comment.user.id != 69946302) && !github.event.issue.pull_request && (github.event.issue.state == 'open')
     steps:
       - name: Add require reply label
         uses: actions-cool/issues-helper@v2

--- a/.github/workflows/reply-label-issue-comment.yml
+++ b/.github/workflows/reply-label-issue-comment.yml
@@ -25,7 +25,7 @@ jobs:
 
   add-label-if-not-author:
     runs-on: ubuntu-latest
-    if: (github.event.issue.user.id != github.event.comment.user.id && user.id != opendigger-bot's id) && !github.event.issue.pull_request && (github.event.issue.state == 'open')
+    if: (github.event.issue.user.id != github.event.comment.user.id && user.id != 69946302) && !github.event.issue.pull_request && (github.event.issue.state == 'open')
     steps:
       - name: Add require reply label
         uses: actions-cool/issues-helper@v2

--- a/.github/workflows/reply-label-issue-comment.yml
+++ b/.github/workflows/reply-label-issue-comment.yml
@@ -25,7 +25,7 @@ jobs:
 
   add-label-if-not-author:
     runs-on: ubuntu-latest
-    if: (github.event.issue.user.id != github.event.comment.user.id) && !github.event.issue.pull_request && (github.event.issue.state == 'open')
+    if: (github.event.issue.user.id != github.event.comment.user.id && user.id != opendigger-bot's id) && !github.event.issue.pull_request && (github.event.issue.state == 'open')
     steps:
       - name: Add require reply label
         uses: actions-cool/issues-helper@v2


### PR DESCRIPTION
fix #1020 

In order to test, I created my own open-digger repo with the updated file. I used an id of other user replacing open-digger-bot's id to fliter. The flitered user' comment was not tagged and other users' comments could be tagged.