### PR TITLE
data: add big data label data

### DIFF
--- a/labeled_data/technology/big_data/analysis_engine.yml
+++ b/labeled_data/technology/big_data/analysis_engine.yml
@@ -1,0 +1,38 @@
+name: Big Data - Analysis Engine
+type: Tech-1
+data:
+  github_repo:
+    - 17165658 # repo:apache/spark
+    - 60246359 # repo:ClickHouse/ClickHouse
+    - 5349565 # repo:prestodb/presto
+    - 84240850 # repo:timescale/timescaledb
+    - 6358188 # repo:apache/druid
+    - 206424 # repo:apache/cassandra
+    - 166515022 # repo:trinodb/trino
+    - 334274271 # repo:opensearch-project/OpenSearch
+    - 138754790 # repo:duckdb/duckdb
+    - 99919302 # repo:apache/doris
+    - 20089857 # repo:apache/hbase
+    - 206444 # repo:apache/hive
+    - 50229487 # repo:apache/lucene-solr
+    - 19961085 # repo:apache/pinot
+    - 28738447 # repo:apache/kylin
+    - 206417 # repo:apache/couchdb
+    - 402945349 # repo:StarRocks/starrocks
+    - 149626591 # repo:uber/aresdb
+    - 158975124 # repo:apache/iotdb
+    - 141376301 # repo:apache/incubator-hugegraph
+    - 44781140 # repo:greenplum-db/gpdb
+    - 5683653 # repo:apache/drill
+    - 202483348 # repo:apache/incubator-kvrocks
+    - 358917318 # repo:apache/arrow-datafusion
+    - 9342529 # repo:crate/crate
+    - 341631350 # repo:apache/lucene
+    - 20473418 # repo:apache/phoenix
+    - 56128733 # repo:apache/impala
+    - 59475316 # repo:eventql/eventql
+    - 41952293 # repo:apache/hawq
+    - 206357 # repo:apache/pig
+    - 341374920 # repo:apache/solr
+    - 9290699 # repo:apache/tez
+    - 507775 # repo:elastic/elasticsearch

--- a/labeled_data/technology/big_data/data_development.yml
+++ b/labeled_data/technology/big_data/data_development.yml
@@ -1,0 +1,8 @@
+name: Big Data - Data Development
+type: Tech-1
+data:
+  github_repo:
+    - 33653601 # repo:jupyter/notebook
+    - 32848140 # repo:apache/zeppelin
+    - 23653453 # repo:pachyderm/pachyderm
+    - 384111310 # repo:apache/incubator-devlake

--- a/labeled_data/technology/big_data/data_integration.yml
+++ b/labeled_data/technology/big_data/data_integration.yml
@@ -1,0 +1,14 @@
+name: Big Data - Data Integration
+type: Tech-1
+data:
+  github_repo:
+    - 117965972 # repo:alibaba/DataX
+    - 50205233 # repo:debezium/debezium
+    - 283046497 # repo:airbytehq/airbyte
+    - 53548867 # repo:dbt-labs/dbt-core
+    - 206317 # repo:apache/camel
+    - 99412308 # repo:apache/incubator-seatunnel
+    - 282994686 # repo:ververica/flink-cdc-connectors
+    - 2153096 # repo:apache/sqoop
+    - 231533573 # repo:apache/inlong
+    - 2198510 # repo:apache/flume

--- a/labeled_data/technology/big_data/data_storage.yml
+++ b/labeled_data/technology/big_data/data_storage.yml
@@ -1,0 +1,19 @@
+name: Big Data - Data Storage
+type: Tech-1
+data:
+  github_repo:
+    - 327859577 # repo:juicedata/juicefs
+    - 76474200 # repo:apache/hudi
+    - 158256479 # repo:apache/iceberg
+    - 7276954 # repo:Alluxio/alluxio
+    - 206459 # repo:apache/avro
+    - 182849188 # repo:delta-io/delta
+    - 3786237 # repo:hazelcast/hazelcast
+    - 20675636 # repo:apache/parquet-mr
+    - 1575956 # repo:apache/bookkeeper
+    - 50647838 # repo:apache/kudu
+    - 41712332 # repo:apache/incubator-pegasus
+    - 62117818 # repo:apache/carbondata
+    - 20675635 # repo:apache/parquet-format
+    - 212382406 # repo:apache/ozone
+    - 25507371 # repo:apache/hadoop-hdfs

--- a/labeled_data/technology/big_data/index.yml
+++ b/labeled_data/technology/big_data/index.yml
@@ -1,0 +1,12 @@
+name: Big Data
+type: Tech-0
+data:
+  label:
+    - visualization
+    - analysis_engine
+    - scheduler
+    - streaming
+    - data_integration
+    - data_development
+    - data_storage
+    - others

--- a/labeled_data/technology/big_data/others.yml
+++ b/labeled_data/technology/big_data/others.yml
@@ -1,0 +1,13 @@
+name: Big Data - Others
+type: Tech-1
+data:
+  github_repo:
+    - 49876476 # repo:apache/shardingsphere
+    - 149026292 # repo:cube-js/cube.js
+    - 23418517 # repo:apache/hadoop
+    - 46398090 # repo:datahub-project/datahub
+    - 21193524 # repo:apache/calcite
+    - 198368711 # repo:apache/incubator-linkis
+    - 114619105 # repo:apache/incubator-kyuubi
+    - 2155500 # repo:apache/bigtop
+    - 17310686 # repo:apache/knox

--- a/labeled_data/technology/big_data/scheduler.yml
+++ b/labeled_data/technology/big_data/scheduler.yml
@@ -1,0 +1,16 @@
+name: Big Data - Scheduler
+type: Tech-1
+data:
+  github_repo:
+    - 33884891 # repo:apache/airflow
+    - 160999 # repo:apache/zookeeper
+    - 51905353 # repo:apache/arrow
+    - 139199684 # repo:PrefectHQ/prefect
+    - 173335706 # repo:apache/dolphinscheduler
+    - 131619646 # repo:dagster-io/dagster
+    - 27911088 # repo:apache/nifi
+    - 204164353 # repo:kestra-io/kestra
+    - 2442457 # repo:apache/ambari
+    - 98013453 # repo:apache/atlas
+    - 2383782 # repo:apache/oozie
+    - 22305416 # repo:apache/ranger

--- a/labeled_data/technology/big_data/streaming.yml
+++ b/labeled_data/technology/big_data/streaming.yml
@@ -1,0 +1,12 @@
+name: Big Data - Streaming
+type: Tech-1
+data:
+  github_repo:
+    - 2211243 # repo:apache/kafka
+    - 20587599 # repo:apache/flink
+    - 62117812 # repo:apache/pulsar
+    - 50904245 # repo:apache/beam
+    - 14135470 # repo:apache/storm
+    - 43158694 # repo:apache/incubator-heron
+    - 32199982 # repo:apache/samza
+    - 188779637 # repo:apache/incubator-streampark

--- a/labeled_data/technology/big_data/visualization.yml
+++ b/labeled_data/technology/big_data/visualization.yml
@@ -1,0 +1,28 @@
+name: Big Data - Visualization
+type: Tech-1
+data:
+  github_repo:
+    - 943149 # repo:d3/d3
+    - 9185792 # repo:apache/echarts
+    - 15111821 # repo:grafana/grafana
+    - 39464018 # repo:apache/superset
+    - 30203935 # repo:metabase/metabase
+    - 13926404 # repo:getredash/redash
+    - 1385122 # repo:matplotlib/matplotlib
+    - 85095608 # repo:airbnb/visx
+    - 45646037 # repo:plotly/plotly.js
+    - 59737212 # repo:antvis/G2
+    - 4704710 # repo:mwaskom/seaborn
+    - 11496279 # repo:c3js/c3
+    - 123345344 # repo:keplergl/kepler.gl
+    - 335164964 # repo:dataease/dataease
+    - 110222380 # repo:alibaba/BizCharts
+    - 39979936 # repo:nhn/tui.chart
+    - 156293506 # repo:microsoft/SandDance
+    - 102447494 # repo:edp963/davinci
+    - 96424863 # repo:TalkingData/inmap
+    - 159273440 # repo:shzlw/poli
+    - 8357227 # repo:biolab/orange3
+    - 37276906 # repo:keen/explorer
+    - 54937496 # repo:PatMartin/Dex
+    - 7833168 # repo:elastic/kibana

--- a/src/label_data_utils.ts
+++ b/src/label_data_utils.ts
@@ -6,7 +6,7 @@ const labelInputDir = '../labeled_data';
 const labelInputPath = path.join(__dirname, labelInputDir);
 
 const supportedTypes = new Set<string>([
-  'Region', 'Company', 'Community', 'Project', 'Foundation'
+  'Region', 'Company', 'Community', 'Project', 'Foundation', 'Tech-0', 'Tech-1',
 ]);
 
 const supportedKey = new Set<string>([


### PR DESCRIPTION
Signed-off-by: frank-zsy <syzhao1988@126.com>

close #1051 

Add `Big Data` related label data, and add `Tech-0` and `Tech-1` as top level and 2nd level technology label type.

I verify the result in my local environment and I will upload several screenshots about the result.

Big data overall label repos count and overall OpenRank trending by year.

<img width="1329" alt="image" src="https://user-images.githubusercontent.com/8512426/202650277-420ea9b4-6c39-4198-8b7d-3e96935fda93.png">

Sub area OpenRank trending by year, only change `groupBy` to `Tech-1` which means group data by 2nd level label.

<img width="1358" alt="image" src="https://user-images.githubusercontent.com/8512426/202650535-0de26ff1-e6cf-4513-bdb9-35c4a771afad.png">

Repo OpenRank trending in sub area, just use `:technology/big_data/data_storage` to access the 2nd level label.

<img width="1332" alt="image" src="https://user-images.githubusercontent.com/8512426/202650663-9b35a990-d693-4ed3-9102-10c1f8b4b659.png">

So all works fine now on my side.