### PR TITLE
data: update database label data (total 206) refer to DB-Engines in Dec, 2022.

### DIFF
--- a/labeled_data/technology/database/document.yml
+++ b/labeled_data/technology/database/document.yml
@@ -2,34 +2,41 @@ name: Database - Document
 type: Tech-1
 data:
   github_repo:
-    - 24494032 # repo:mysql/mysql-server
-    - 927442 # repo:postgres/postgres
-    - 19816070 # repo:MariaDB/server
-    - 44781140 # repo:greenplum-db/gpdb
-    - 192418550 # repo:oracle/nosql-go-sdk
-    - 5683653 # repo:apache/drill
-    - 41986369 # repo:pingcap/tidb
-    - 316690542 # repo:MonetDB/MonetDB
-    - 166515022 # repo:trinodb/trino
-    - 50874442 # repo:citusdata/citus
-    - 114187903 # repo:apple/foundationdb
-    - 156018 # repo:redis/redis
-    - 3786237 # repo:hazelcast/hazelcast
-    - 124315604 # repo:aerospike/aerospike-server
-    - 911980 # repo:tarantool/tarantool
-    - 28956774 # repo:Alachisoft/NCache
     - 108110 # repo:mongodb/mongo
+    - 419004753 # repo:databricks/dbt-databricks
     - 7948548 # repo:couchbase/couchbase-lite-ios
     - 206417 # repo:apache/couchdb
-    - 49896881 # repo:marklogic/marklogic-data-hub
     - 4044891 # repo:realm/realm-cocoa
-    - 226992533 # repo:googleapis/python-firestore
+    - 124315604 # repo:aerospike/aerospike-server
+    - 3788366 # repo:openlink/virtuoso-opensource
     - 2649214 # repo:arangodb/arangodb
+    - 7083240 # repo:orientechnologies/orientdb
+    - 192418550 # repo:oracle/nosql-go-sdk
     - 542714 # repo:ravendb/ravendb
-    - 6452529 # repo:rethinkdb/rethinkdb
     - 714074 # repo:pouchdb/pouchdb
+    - 6452529 # repo:rethinkdb/rethinkdb
+    - 5683653 # repo:apache/drill
+    - 114187903 # repo:apple/foundationdb
     - 141378316 # repo:beardedeagle/mnesiac
     - 23315232 # repo:mbdavid/LiteDB
-    - 3788366 # repo:openlink/virtuoso-opensource
-    - 7083240 # repo:orientechnologies/orientdb
-    - 507775 # repo:elastic/elasticsearch
+    - 51290852 # repo:bigchaindb/bigchaindb
+    - 25780780 # repo:AlaSQL/alasql
+    - 39519916 # repo:percona/percona-server-mongodb
+    - 11654790 # repo:techfort/LokiJS
+    - 456549280 # repo:ydb-platform/ydb
+    - 188354257 # repo:SequoiaDB/SequoiaDB
+    - 436658287 # repo:surrealdb/surrealdb
+    - 6427744 # repo:Softmotions/ejdb
+    - 396867188 # repo:ArcadeData/arcadedb
+    - 137869753 # repo:appy-one/acebase
+    - 125824259 # repo:xtdb/xtdb
+    - 34056205 # repo:sachin-sinha/BangDB
+    - 50836580 # repo:iboxdb/ftserver
+    - 61179047 # repo:Alachisoft/NosDB
+    - 86339169 # repo:torodb/server
+    - 8799170 # repo:DevrexLabs/OrigoDB
+    - 26573806 # repo:mgholam/RaptorDB-Document
+    - 533032 # repo:LinkedInAttic/sensei
+    - 10153163 # repo:priitj/whitedb
+    - 33053071 # repo:oberasoftware/jasdb
+

--- a/labeled_data/technology/database/document.yml
+++ b/labeled_data/technology/database/document.yml
@@ -2,29 +2,53 @@ name: Database - Document
 type: Tech-1
 data:
   github_repo:
+    - 24494032 # repo:mysql/mysql-server
+    - 927442 # repo:postgres/postgres
     - 108110 # repo:mongodb/mongo
+    - 156018 # repo:redis/redis
+    - 507775 # repo:elastic/elasticsearch
+    - 19816070 # repo:MariaDB/server
     - 419004753 # repo:databricks/dbt-databricks
     - 7948548 # repo:couchbase/couchbase-lite-ios
+    - 56128733 # repo:apache/impala
     - 206417 # repo:apache/couchdb
+    - 44781140 # repo:greenplum-db/gpdb
+    - 226992533 # repo:googleapis/python-firestore
+    - 3786237 # repo:hazelcast/hazelcast
+    - 49896881 # repo:marklogic/marklogic-data-hub
     - 4044891 # repo:realm/realm-cocoa
     - 124315604 # repo:aerospike/aerospike-server
     - 3788366 # repo:openlink/virtuoso-opensource
     - 2649214 # repo:arangodb/arangodb
     - 7083240 # repo:orientechnologies/orientdb
+    - 105944401 # repo:yugabyte/yugabyte-db
     - 192418550 # repo:oracle/nosql-go-sdk
+    - 166515022 # repo:trinodb/trino
     - 542714 # repo:ravendb/ravendb
     - 714074 # repo:pouchdb/pouchdb
+    - 41986369 # repo:pingcap/tidb
     - 6452529 # repo:rethinkdb/rethinkdb
+    - 50874442 # repo:citusdata/citus
     - 5683653 # repo:apache/drill
+    - 4859 # repo:jcrosby/cloudkit
+    - 316690542 # repo:MonetDB/MonetDB
     - 114187903 # repo:apple/foundationdb
+    - 911980 # repo:tarantool/tarantool
     - 141378316 # repo:beardedeagle/mnesiac
     - 23315232 # repo:mbdavid/LiteDB
+    - 372536760 # repo:oceanbase/oceanbase
+    - 28956774 # repo:Alachisoft/NCache
+    - 276117477 # repo:opengauss-mirror/openGauss-server
     - 51290852 # repo:bigchaindb/bigchaindb
+    - 9342529 # repo:crate/crate
+    - 198683574 # repo:dolthub/dolt
+    - 41443810 # repo:Postgres-XL/Postgres-XL
     - 25780780 # repo:AlaSQL/alasql
     - 39519916 # repo:percona/percona-server-mongodb
     - 11654790 # repo:techfort/LokiJS
     - 456549280 # repo:ydb-platform/ydb
     - 188354257 # repo:SequoiaDB/SequoiaDB
+    - 198466472 # repo:terminusdb/terminusdb
     - 436658287 # repo:surrealdb/surrealdb
     - 6427744 # repo:Softmotions/ejdb
     - 396867188 # repo:ArcadeData/arcadedb
@@ -39,4 +63,3 @@ data:
     - 533032 # repo:LinkedInAttic/sensei
     - 10153163 # repo:priitj/whitedb
     - 33053071 # repo:oberasoftware/jasdb
-

--- a/labeled_data/technology/database/graph.yml
+++ b/labeled_data/technology/database/graph.yml
@@ -2,7 +2,13 @@ name: Database - Graph
 type: Tech-1
 data:
   github_repo:
+    - 156018 # repo:redis/redis
+    - 19816070 # repo:MariaDB/server
     - 6650539 # repo:neo4j/neo4j
+    - 3788366 # repo:openlink/virtuoso-opensource
+    - 2649214 # repo:arangodb/arangodb
+    - 7083240 # repo:orientechnologies/orientdb
+    - 542714 # repo:ravendb/ravendb
     - 77385607 # repo:JanusGraph/janusgraph
     - 41349039 # repo:dgraph-io/dgraph
     - 2282376 # repo:apache/giraph
@@ -16,7 +22,10 @@ data:
     - 605999 # repo:twitter-archive/flockdb
     - 305513242 # repo:fluree/db
     - 198466472 # repo:terminusdb/terminusdb
+    - 436658287 # repo:surrealdb/surrealdb
+    - 396867188 # repo:ArcadeData/arcadedb
     - 38727503 # repo:hypergraphdb/hypergraphdb
+    - 34056205 # repo:sachin-sinha/BangDB
     - 73235061 # repo:rayokota/hgraphdb
     - 57401138 # repo:bitnine-oss/agensgraph
-    
+    - 55578752 # repo:stellardb/StellarDB

--- a/labeled_data/technology/database/graph.yml
+++ b/labeled_data/technology/database/graph.yml
@@ -2,17 +2,21 @@ name: Database - Graph
 type: Tech-1
 data:
   github_repo:
-    - 19816070 # repo:MariaDB/server
-    - 156018 # repo:redis/redis
-    - 2649214 # repo:arangodb/arangodb
-    - 542714 # repo:ravendb/ravendb
     - 6650539 # repo:neo4j/neo4j
-    - 3788366 # repo:openlink/virtuoso-opensource
-    - 7083240 # repo:orientechnologies/orientdb
     - 77385607 # repo:JanusGraph/janusgraph
     - 41349039 # repo:dgraph-io/dgraph
     - 2282376 # repo:apache/giraph
-    - 146459443 # repo:vesoft-inc/nebula
     - 63110867 # repo:vaticle/typedb
-    - 81411018 # repo:microsoft/GraphEngine
+    - 146459443 # repo:vesoft-inc/nebula
     - 48451041 # repo:blazegraph/database
+    - 297302063 # repo:memgraph/memgraph
+    - 81411018 # repo:microsoft/GraphEngine
+    - 141376301 # repo:apache/incubator-hugegraph
+    - 30449481 # repo:apache/tinkerpop
+    - 605999 # repo:twitter-archive/flockdb
+    - 305513242 # repo:fluree/db
+    - 198466472 # repo:terminusdb/terminusdb
+    - 38727503 # repo:hypergraphdb/hypergraphdb
+    - 73235061 # repo:rayokota/hgraphdb
+    - 57401138 # repo:bitnine-oss/agensgraph
+    

--- a/labeled_data/technology/database/key_value.yml
+++ b/labeled_data/technology/database/key_value.yml
@@ -2,29 +2,42 @@ name: Database - Key-value
 type: Tech-1
 data:
   github_repo:
-    - 192418550 # repo:oracle/nosql-go-sdk
-    - 166515022 # repo:trinodb/trino
-    - 114187903 # repo:apple/foundationdb
     - 156018 # repo:redis/redis
     - 184981 # repo:memcached/memcached
-    - 11225014 # repo:etcd-io/etcd
     - 3786237 # repo:hazelcast/hazelcast
+    - 11225014 # repo:etcd-io/etcd
     - 17224514 # repo:ehcache/ehcache3
-    - 791522 # repo:basho/riak_kv
-    - 124315604 # repo:aerospike/aerospike-server
     - 31006158 # repo:apache/ignite
+    - 791522 # repo:basho/riak_kv
     - 6934395 # repo:facebook/rocksdb
     - 23405758 # repo:google/leveldb
     - 1050944 # repo:infinispan/infinispan
+    - 2380364 # repo:berkeleydb/libdb
     - 34406933 # repo:LMDB/lmdb
     - 34839383 # repo:apache/geode
     - 911980 # repo:tarantool/tarantool
-    - 7357595 # repo:zopefoundation/ZODB
     - 28956774 # repo:Alachisoft/NCache
-    - 7948548 # repo:couchbase/couchbase-lite-ios
-    - 2649214 # repo:arangodb/arangodb
-    - 52420005 # repo:griddb/griddb
-    - 7083240 # repo:orientechnologies/orientdb
-    - 81411018 # repo:microsoft/GraphEngine
-    - 28449431 # repo:scylladb/scylla
-    - 2380364 # repo:berkeleydb/libdb
+    - 7357595 # repo:zopefoundation/ZODB
+    - 1202421 # repo:hibari/hibari
+    - 94593596 # repo:etcd-io/bbolt
+    - 5453989 # repo:jankotek/mapdb
+    - 33605302 # repo:scalaris-team/scalaris
+    - 168712350 # repo:Snapchat/KeyDB
+    - 3502280 # repo:hthetiot/Tokyo-Tyrant
+    - 214605 # repo:voldemort/voldemort
+    - 462329984 # repo:speedb-io/speedb
+    - 220186120 # repo:codenotary/immudb
+    - 28457976 # repo:AlticeLabsProjects/kyoto
+    - 3114475 # repo:tomp2p/TomP2P
+    - 19296225 # repo:ledisdb/ledisdb
+    - 4712089 # repo:reverbrain/elliptics
+    - 10529222 # repo:rescrv/HyperLevelDB
+    - 31363586 # repo:STSSoft/STSdb4
+    - 811881 # repo:cruppstahl/upscaledb
+    - 80087836 # repo:dgraph-io/badger
+    - 3115025 # repo:dlitz/resin
+    - 121126549 # repo:simerplaha/SwayDB
+    - 88422672 # repo:bergdb/bergdb
+    - 33275300 # repo:cachelot/cachelot
+    - 96580430 # repo:datajaguar/jaguardb
+    - 278320002 # repo:estraier/tkrzw

--- a/labeled_data/technology/database/key_value.yml
+++ b/labeled_data/technology/database/key_value.yml
@@ -3,28 +3,41 @@ type: Tech-1
 data:
   github_repo:
     - 156018 # repo:redis/redis
+    - 7948548 # repo:couchbase/couchbase-lite-ios
     - 184981 # repo:memcached/memcached
     - 3786237 # repo:hazelcast/hazelcast
     - 11225014 # repo:etcd-io/etcd
+    - 124315604 # repo:aerospike/aerospike-server
     - 17224514 # repo:ehcache/ehcache3
     - 31006158 # repo:apache/ignite
+    - 2649214 # repo:arangodb/arangodb
+    - 28449431 # repo:scylladb/scylla
     - 791522 # repo:basho/riak_kv
+    - 7083240 # repo:orientechnologies/orientdb
     - 6934395 # repo:facebook/rocksdb
+    - 192418550 # repo:oracle/nosql-go-sdk
+    - 166515022 # repo:trinodb/trino
     - 23405758 # repo:google/leveldb
     - 1050944 # repo:infinispan/infinispan
     - 2380364 # repo:berkeleydb/libdb
     - 34406933 # repo:LMDB/lmdb
+    - 242776849 # repo:oracle/coherence
+    - 170496871 # repo:gridgain/gridgain
     - 34839383 # repo:apache/geode
+    - 114187903 # repo:apple/foundationdb
+    - 52420005 # repo:griddb/griddb
     - 911980 # repo:tarantool/tarantool
     - 28956774 # repo:Alachisoft/NCache
     - 7357595 # repo:zopefoundation/ZODB
     - 1202421 # repo:hibari/hibari
+    - 81411018 # repo:microsoft/GraphEngine
     - 94593596 # repo:etcd-io/bbolt
     - 5453989 # repo:jankotek/mapdb
     - 33605302 # repo:scalaris-team/scalaris
     - 168712350 # repo:Snapchat/KeyDB
     - 3502280 # repo:hthetiot/Tokyo-Tyrant
     - 214605 # repo:voldemort/voldemort
+    - 396867188 # repo:ArcadeData/arcadedb
     - 462329984 # repo:speedb-io/speedb
     - 220186120 # repo:codenotary/immudb
     - 28457976 # repo:AlticeLabsProjects/kyoto
@@ -33,6 +46,7 @@ data:
     - 4712089 # repo:reverbrain/elliptics
     - 10529222 # repo:rescrv/HyperLevelDB
     - 31363586 # repo:STSSoft/STSdb4
+    - 320459354 # repo:bytedance/terarkdb
     - 811881 # repo:cruppstahl/upscaledb
     - 80087836 # repo:dgraph-io/badger
     - 3115025 # repo:dlitz/resin

--- a/labeled_data/technology/database/multivalue.yml
+++ b/labeled_data/technology/database/multivalue.yml
@@ -2,6 +2,7 @@ name: Database - Multivalue
 type: Tech-1
 data:
   github_repo:
+    - 34215181 # repo:jrmarino/AdaBase
     - 17699493 # repo:cran/scidb
     - 5407611 # repo:dioptre/rasdaman
     - 1984888 # repo:gregjurman/openqm

--- a/labeled_data/technology/database/multivalue.yml
+++ b/labeled_data/technology/database/multivalue.yml
@@ -5,4 +5,3 @@ data:
     - 17699493 # repo:cran/scidb
     - 5407611 # repo:dioptre/rasdaman
     - 1984888 # repo:gregjurman/openqm
-    - 208728772 # repo:milvus-io/milvus

--- a/labeled_data/technology/database/native_xml.yml
+++ b/labeled_data/technology/database/native_xml.yml
@@ -2,9 +2,6 @@ name: Database - Native XML
 type: Tech-1
 data:
   github_repo:
-    - 49896881 # repo:marklogic/marklogic-data-hub
-    - 3788366 # repo:openlink/virtuoso-opensource
-    - 2380364 # repo:berkeleydb/libdb
     - 1374129 # repo:BaseXdb/basex
     - 5841618 # repo:sedna/sedna
     - 11695619 # repo:eXist-db/exist

--- a/labeled_data/technology/database/native_xml.yml
+++ b/labeled_data/technology/database/native_xml.yml
@@ -2,6 +2,9 @@ name: Database - Native XML
 type: Tech-1
 data:
   github_repo:
+    - 49896881 # repo:marklogic/marklogic-data-hub
+    - 3788366 # repo:openlink/virtuoso-opensource
+    - 2380364 # repo:berkeleydb/libdb
     - 1374129 # repo:BaseXdb/basex
     - 5841618 # repo:sedna/sedna
     - 11695619 # repo:eXist-db/exist

--- a/labeled_data/technology/database/object_oriented.yml
+++ b/labeled_data/technology/database/object_oriented.yml
@@ -5,3 +5,7 @@ data:
     - 204261394 # repo:iboxdb/db4o-gpl
     - 79901405 # repo:objectbox/objectbox-java
     - 124423054 # repo:The-Alchemist/perst
+    - 88111990 # repo:zhihu/Matisse
+    - 246343828 # repo:atoti/atoti
+    - 273564373 # repo:morecraf/Siaqodb
+    - 8799170 # repo:DevrexLabs/OrigoDB

--- a/labeled_data/technology/database/rdf.yml
+++ b/labeled_data/technology/database/rdf.yml
@@ -2,11 +2,16 @@ name: Database - RDF
 type: Tech-1
 data:
   github_repo:
+    - 49896881 # repo:marklogic/marklogic-data-hub
+    - 3788366 # repo:openlink/virtuoso-opensource
     - 7437073 # repo:apache/jena
+    - 48451041 # repo:blazegraph/database
     - 49670957 # repo:eclipse/rdf4j
     - 248094 # repo:4store/4store
     - 31719727 # repo:esarbanis/strabon
     - 855939 # repo:dajobe/librdf
+    - 198466472 # repo:terminusdb/terminusdb
     - 754873 # repo:njh/redstore
     - 16710751 # repo:quoll/mulgara
+    - 1340162 # repo:dydra/dydra
     - 8335020 # repo:BrightstarDB/BrightstarDB

--- a/labeled_data/technology/database/rdf.yml
+++ b/labeled_data/technology/database/rdf.yml
@@ -2,9 +2,11 @@ name: Database - RDF
 type: Tech-1
 data:
   github_repo:
-    - 49896881 # repo:marklogic/marklogic-data-hub
-    - 3788366 # repo:openlink/virtuoso-opensource
     - 7437073 # repo:apache/jena
-    - 48451041 # repo:blazegraph/database
     - 49670957 # repo:eclipse/rdf4j
     - 248094 # repo:4store/4store
+    - 31719727 # repo:esarbanis/strabon
+    - 855939 # repo:dajobe/librdf
+    - 754873 # repo:njh/redstore
+    - 16710751 # repo:quoll/mulgara
+    - 8335020 # repo:BrightstarDB/BrightstarDB

--- a/labeled_data/technology/database/relational.yml
+++ b/labeled_data/technology/database/relational.yml
@@ -5,8 +5,11 @@ data:
     - 24494032 # repo:mysql/mysql-server
     - 927442 # repo:postgres/postgres
     - 176278485 # repo:sqlite/sqlite
+    - 697976 # repo:twitter-archive/snowflake
     - 19816070 # repo:MariaDB/server
     - 206444 # repo:apache/hive
+    - 419004753 # repo:databricks/dbt-databricks
+    - 4407129 # repo:postgis/postgis
     - 54005538 # repo:FirebirdSQL/firebird
     - 17165658 # repo:apache/spark
     - 56128733 # repo:apache/impala
@@ -15,22 +18,37 @@ data:
     - 44781140 # repo:greenplum-db/gpdb
     - 33745913 # repo:h2database/h2database
     - 16563587 # repo:cockroachdb/cockroach
+    - 89848289 # repo:KxSystems/kdb
+    - 600860 # repo:fosslc/Ingres
+    - 3788366 # repo:openlink/virtuoso-opensource
+    - 31006158 # repo:apache/ignite
     - 1918497 # repo:apache/derby
     - 101723057 # repo:ryenus/hsqldb
+    - 84240850 # repo:timescale/timescaledb
     - 105944401 # repo:yugabyte/yugabyte-db
+    - 192418550 # repo:oracle/nosql-go-sdk
     - 166515022 # repo:trinodb/trino
     - 41986369 # repo:pingcap/tidb
     - 30753733 # repo:percona/percona-server
     - 50874442 # repo:citusdata/citus
     - 20473418 # repo:apache/phoenix
+    - 5683653 # repo:apache/drill
+    - 170496871 # repo:gridgain/gridgain
     - 90541149 # repo:heavyai/heavydb
     - 316690542 # repo:MonetDB/MonetDB
     - 6358188 # repo:apache/druid
+    - 7171304 # repo:illarionov/SpatiaLite
     - 2445970 # repo:VoltDB/voltdb
+    - 196353673 # repo:taosdata/TDengine
+    - 114187903 # repo:apple/foundationdb
+    - 52420005 # repo:griddb/griddb
+    - 911980 # repo:tarantool/tarantool
+    - 19257422 # repo:questdb/questdb
     - 138754790 # repo:duckdb/duckdb
     - 28738447 # repo:apache/kylin
     - 52080367 # repo:CUBRID/cubrid
     - 41952293 # repo:apache/hawq
+    - 63110867 # repo:vaticle/typedb
     - 120703602 # repo:ALTIBASE/altibase
     - 372536760 # repo:oceanbase/oceanbase
     - 3556910 # repo:sql-js/sql.js
@@ -42,13 +60,19 @@ data:
     - 41443810 # repo:Postgres-XL/Postgres-XL
     - 17971138 # repo:apache/tajo
     - 36349344 # repo:apache/trafodion
+    - 25780780 # repo:AlaSQL/alasql
     - 99919302 # repo:apache/doris
     - 19961085 # repo:apache/pinot
+    - 456549280 # repo:ydb-platform/ydb
     - 91593042 # repo:bloomberg/comdb2
+    - 188354257 # repo:SequoiaDB/SequoiaDB
     - 24650236 # repo:google/lovefield
     - 14702444 # repo:pipelinedb/pipelinedb
+    - 40127179 # repo:featurebasedb/featurebase
+    - 220186120 # repo:codenotary/immudb
     - 16109206 # repo:biokoda/actordb
+    - 9074548 # repo:orbisgis/h2gis
     - 151762200 # repo:CptTZ/SmallSQL
+    - 57401138 # repo:bitnine-oss/agensgraph
     - 129072319 # repo:CovenantSQL/CovenantSQL
     - 341208515 # repo:edgelesssys/edgelessdb
-    

--- a/labeled_data/technology/database/relational.yml
+++ b/labeled_data/technology/database/relational.yml
@@ -8,36 +8,47 @@ data:
     - 19816070 # repo:MariaDB/server
     - 206444 # repo:apache/hive
     - 54005538 # repo:FirebirdSQL/firebird
-    - 44781140 # repo:greenplum-db/gpdb
+    - 17165658 # repo:apache/spark
+    - 56128733 # repo:apache/impala
     - 5349565 # repo:prestodb/presto
     - 60246359 # repo:ClickHouse/ClickHouse
+    - 44781140 # repo:greenplum-db/gpdb
     - 33745913 # repo:h2database/h2database
     - 16563587 # repo:cockroachdb/cockroach
-    - 101723057 # repo:ryenus/hsqldb
     - 1918497 # repo:apache/derby
-    - 192418550 # repo:oracle/nosql-go-sdk
-    - 20473418 # repo:apache/phoenix
-    - 5683653 # repo:apache/drill
+    - 101723057 # repo:ryenus/hsqldb
+    - 105944401 # repo:yugabyte/yugabyte-db
+    - 166515022 # repo:trinodb/trino
     - 41986369 # repo:pingcap/tidb
     - 30753733 # repo:percona/percona-server
-    - 316690542 # repo:MonetDB/MonetDB
-    - 166515022 # repo:trinodb/trino
-    - 2445970 # repo:VoltDB/voltdb
     - 50874442 # repo:citusdata/citus
+    - 20473418 # repo:apache/phoenix
     - 90541149 # repo:heavyai/heavydb
-    - 114187903 # repo:apple/foundationdb
+    - 316690542 # repo:MonetDB/MonetDB
+    - 6358188 # repo:apache/druid
+    - 2445970 # repo:VoltDB/voltdb
+    - 138754790 # repo:duckdb/duckdb
     - 28738447 # repo:apache/kylin
     - 52080367 # repo:CUBRID/cubrid
-    - 31006158 # repo:apache/ignite
-    - 911980 # repo:tarantool/tarantool
-    - 89848289 # repo:KxSystems/kdb
-    - 84240850 # repo:timescale/timescaledb
-    - 6358188 # repo:apache/druid
-    - 52420005 # repo:griddb/griddb
-    - 19257422 # repo:questdb/questdb
-    - 196353673 # repo:taosdata/TDengine
-    - 3788366 # repo:openlink/virtuoso-opensource
-    - 63110867 # repo:vaticle/typedb
-    - 4407129 # repo:postgis/postgis
-    - 7171304 # repo:illarionov/SpatiaLite
-    - 9074548 # repo:orbisgis/h2gis
+    - 41952293 # repo:apache/hawq
+    - 120703602 # repo:ALTIBASE/altibase
+    - 372536760 # repo:oceanbase/oceanbase
+    - 3556910 # repo:sql-js/sql.js
+    - 276117477 # repo:opengauss-mirror/openGauss-server
+    - 339993112 # repo:matrixorigin/matrixone
+    - 9342529 # repo:crate/crate
+    - 8582237 # repo:splicemachine/spliceengine
+    - 198683574 # repo:dolthub/dolt
+    - 41443810 # repo:Postgres-XL/Postgres-XL
+    - 17971138 # repo:apache/tajo
+    - 36349344 # repo:apache/trafodion
+    - 99919302 # repo:apache/doris
+    - 19961085 # repo:apache/pinot
+    - 91593042 # repo:bloomberg/comdb2
+    - 24650236 # repo:google/lovefield
+    - 14702444 # repo:pipelinedb/pipelinedb
+    - 16109206 # repo:biokoda/actordb
+    - 151762200 # repo:CptTZ/SmallSQL
+    - 129072319 # repo:CovenantSQL/CovenantSQL
+    - 341208515 # repo:edgelesssys/edgelessdb
+    

--- a/labeled_data/technology/database/search_engine.yml
+++ b/labeled_data/technology/database/search_engine.yml
@@ -2,14 +2,14 @@ name: Database - Search Engine
 type: Tech-1
 data:
   github_repo:
-    - 166515022 # repo:trinodb/trino
-    - 156018 # repo:redis/redis
-    - 28956774 # repo:Alachisoft/NCache
-    - 108110 # repo:mongodb/mongo
-    - 49896881 # repo:marklogic/marklogic-data-hub
-    - 2649214 # repo:arangodb/arangodb
-    - 3788366 # repo:openlink/virtuoso-opensource
     - 507775 # repo:elastic/elasticsearch
     - 341374920 # repo:apache/solr
+    - 334274271 # repo:opensearch-project/OpenSearch
     - 36992044 # repo:sphinxsearch/sphinx
-    - 41209174 # repo:strapdata/elassandra
+    - 735981 # repo:xapian/xapian
+    - 130688011 # repo:meilisearch/meilisearch
+    - 208728772 # repo:milvus-io/milvus
+    - 55072677 # repo:semi-technologies/weaviate
+    - 79317191 # repo:typesense/typesense
+    - 268163609 # repo:qdrant/qdrant
+    - 95614931 # repo:manticoresoftware/manticoresearch

--- a/labeled_data/technology/database/search_engine.yml
+++ b/labeled_data/technology/database/search_engine.yml
@@ -2,13 +2,22 @@ name: Database - Search Engine
 type: Tech-1
 data:
   github_repo:
+    - 108110 # repo:mongodb/mongo
+    - 156018 # repo:redis/redis
     - 507775 # repo:elastic/elasticsearch
     - 341374920 # repo:apache/solr
     - 334274271 # repo:opensearch-project/OpenSearch
+    - 49896881 # repo:marklogic/marklogic-data-hub
     - 36992044 # repo:sphinxsearch/sphinx
+    - 3788366 # repo:openlink/virtuoso-opensource
+    - 2649214 # repo:arangodb/arangodb
+    - 166515022 # repo:trinodb/trino
+    - 28956774 # repo:Alachisoft/NCache
     - 735981 # repo:xapian/xapian
+    - 9342529 # repo:crate/crate
     - 130688011 # repo:meilisearch/meilisearch
     - 208728772 # repo:milvus-io/milvus
+    - 41209174 # repo:strapdata/elassandra
     - 55072677 # repo:semi-technologies/weaviate
     - 79317191 # repo:typesense/typesense
     - 268163609 # repo:qdrant/qdrant

--- a/labeled_data/technology/database/spatial.yml
+++ b/labeled_data/technology/database/spatial.yml
@@ -2,27 +2,8 @@ name: Database - Spatial
 type: Tech-1
 data:
   github_repo:
-    - 24494032 # repo:mysql/mysql-server
-    - 927442 # repo:postgres/postgres
-    - 19816070 # repo:MariaDB/server
-    - 44781140 # repo:greenplum-db/gpdb
-    - 33745913 # repo:h2database/h2database
-    - 316690542 # repo:MonetDB/MonetDB
-    - 166515022 # repo:trinodb/trino
-    - 90541149 # repo:heavyai/heavydb
-    - 156018 # repo:redis/redis
-    - 124315604 # repo:aerospike/aerospike-server
-    - 911980 # repo:tarantool/tarantool
-    - 108110 # repo:mongodb/mongo
-    - 7948548 # repo:couchbase/couchbase-lite-ios
-    - 206417 # repo:apache/couchdb
-    - 542714 # repo:ravendb/ravendb
-    - 6452529 # repo:rethinkdb/rethinkdb
-    - 13124802 # repo:influxdata/influxdb
-    - 3788366 # repo:openlink/virtuoso-opensource
-    - 507775 # repo:elastic/elasticsearch
-    - 341374920 # repo:apache/solr
     - 4407129 # repo:postgis/postgis
     - 7171304 # repo:illarionov/SpatiaLite
     - 93667206 # repo:geomesa/geomesa-geoserver
     - 9074548 # repo:orbisgis/h2gis
+    

--- a/labeled_data/technology/database/spatial.yml
+++ b/labeled_data/technology/database/spatial.yml
@@ -2,8 +2,30 @@ name: Database - Spatial
 type: Tech-1
 data:
   github_repo:
+    - 24494032 # repo:mysql/mysql-server
+    - 927442 # repo:postgres/postgres
+    - 108110 # repo:mongodb/mongo
+    - 156018 # repo:redis/redis
+    - 507775 # repo:elastic/elasticsearch
+    - 19816070 # repo:MariaDB/server
+    - 341374920 # repo:apache/solr
+    - 13124802 # repo:influxdata/influxdb
     - 4407129 # repo:postgis/postgis
+    - 7948548 # repo:couchbase/couchbase-lite-ios
+    - 206417 # repo:apache/couchdb
+    - 44781140 # repo:greenplum-db/gpdb
+    - 33745913 # repo:h2database/h2database
+    - 124315604 # repo:aerospike/aerospike-server
+    - 3788366 # repo:openlink/virtuoso-opensource
+    - 166515022 # repo:trinodb/trino
+    - 542714 # repo:ravendb/ravendb
+    - 6452529 # repo:rethinkdb/rethinkdb
+    - 90541149 # repo:heavyai/heavydb
+    - 316690542 # repo:MonetDB/MonetDB
     - 7171304 # repo:illarionov/SpatiaLite
+    - 911980 # repo:tarantool/tarantool
+    - 276117477 # repo:opengauss-mirror/openGauss-server
     - 93667206 # repo:geomesa/geomesa-geoserver
+    - 41443810 # repo:Postgres-XL/Postgres-XL
+    - 34056205 # repo:sachin-sinha/BangDB
     - 9074548 # repo:orbisgis/h2gis
-    

--- a/labeled_data/technology/database/time_series.yml
+++ b/labeled_data/technology/database/time_series.yml
@@ -2,26 +2,25 @@ name: Database - Time Series
 type: Tech-1
 data:
   github_repo:
-    - 60246359 # repo:ClickHouse/ClickHouse
-    - 166515022 # repo:trinodb/trino
-    - 156018 # repo:redis/redis
-    - 108110 # repo:mongodb/mongo
-    - 542714 # repo:ravendb/ravendb
     - 13124802 # repo:influxdata/influxdb
-    - 89848289 # repo:KxSystems/kdb
-    - 6838921 # repo:prometheus/prometheus
     - 4254338 # repo:graphite-project/graphite-web
+    - 6838921 # repo:prometheus/prometheus
     - 84240850 # repo:timescale/timescaledb
-    - 6358188 # repo:apache/druid
     - 5761553 # repo:oetiker/rrdtool-1.x
     - 865412 # repo:OpenTSDB/opentsdb
-    - 52420005 # repo:griddb/griddb
-    - 8039659 # repo:kairosdb/kairosdb
-    - 19257422 # repo:questdb/questdb
-    - 150954997 # repo:VictoriaMetrics/VictoriaMetrics
     - 196353673 # repo:taosdata/TDengine
-    - 59412136 # repo:basho-labs/Riak-TS-JDBC-Driver
+    - 52420005 # repo:griddb/griddb
+    - questdb/questd # not found
+    - 150954997 # repo:VictoriaMetrics/VictoriaMetrics
+    - 8039659 # repo:kairosdb/kairosdb
     - 61153677 # repo:m3db/m3
     - 158975124 # repo:apache/iotdb
+    - 59412136 # repo:basho-labs/Riak-TS-JDBC-Driver
+    - 36483902 # repo:spotify/heroic
+    - 55093657 # repo:SiriDB/siridb-server
+    - 17705626 # repo:hawkular/hawkular-metrics
     - 10081109 # repo:rackerlabs/blueflood
-    - 79901405 # repo:objectbox/objectbox-java
+    - 15682781 # repo:sitewhere/sitewhere
+    - 50594316 # repo:senx/warp10-platform
+    - 16189524 # repo:OpenNMS/newts
+    - 135549948 # repo:radicalbit/NSDb

--- a/labeled_data/technology/database/time_series.yml
+++ b/labeled_data/technology/database/time_series.yml
@@ -2,25 +2,38 @@ name: Database - Time Series
 type: Tech-1
 data:
   github_repo:
+    - 108110 # repo:mongodb/mongo
+    - 156018 # repo:redis/redis
     - 13124802 # repo:influxdata/influxdb
+    - 60246359 # repo:ClickHouse/ClickHouse
+    - 89848289 # repo:KxSystems/kdb
     - 4254338 # repo:graphite-project/graphite-web
     - 6838921 # repo:prometheus/prometheus
     - 84240850 # repo:timescale/timescaledb
+    - 166515022 # repo:trinodb/trino
+    - 542714 # repo:ravendb/ravendb
     - 5761553 # repo:oetiker/rrdtool-1.x
     - 865412 # repo:OpenTSDB/opentsdb
+    - 6358188 # repo:apache/druid
     - 196353673 # repo:taosdata/TDengine
     - 52420005 # repo:griddb/griddb
-    - questdb/questd # not found
+    - 19257422 # repo:questdb/questdb
+    - 79901405 # repo:objectbox/objectbox-java
+    - 9342529 # repo:crate/crate
     - 150954997 # repo:VictoriaMetrics/VictoriaMetrics
     - 8039659 # repo:kairosdb/kairosdb
     - 61153677 # repo:m3db/m3
     - 158975124 # repo:apache/iotdb
     - 59412136 # repo:basho-labs/Riak-TS-JDBC-Driver
+    - 396867188 # repo:ArcadeData/arcadedb
     - 36483902 # repo:spotify/heroic
+    - 34056205 # repo:sachin-sinha/BangDB
     - 55093657 # repo:SiriDB/siridb-server
+    - 95614931 # repo:manticoresoftware/manticoresearch
     - 17705626 # repo:hawkular/hawkular-metrics
     - 10081109 # repo:rackerlabs/blueflood
     - 15682781 # repo:sitewhere/sitewhere
     - 50594316 # repo:senx/warp10-platform
+    - 191442206 # repo:kashirin-alex/swc-db
     - 16189524 # repo:OpenNMS/newts
     - 135549948 # repo:radicalbit/NSDb

--- a/labeled_data/technology/database/wide_column.yml
+++ b/labeled_data/technology/database/wide_column.yml
@@ -2,9 +2,9 @@ name: Database - Wide Column
 type: Tech-1
 data:
   github_repo:
-    - 166515022 # repo:trinodb/trino
     - 206424 # repo:apache/cassandra
     - 20089857 # repo:apache/hbase
     - 2524488 # repo:apache/accumulo
     - 28449431 # repo:scylladb/scylla
     - 41209174 # repo:strapdata/elassandra
+    - 191442206 # repo:kashirin-alex/swc-db

--- a/labeled_data/technology/database/wide_column.yml
+++ b/labeled_data/technology/database/wide_column.yml
@@ -6,5 +6,8 @@ data:
     - 20089857 # repo:apache/hbase
     - 2524488 # repo:apache/accumulo
     - 28449431 # repo:scylladb/scylla
+    - 105944401 # repo:yugabyte/yugabyte-db
+    - 166515022 # repo:trinodb/trino
+    - 372536760 # repo:oceanbase/oceanbase
     - 41209174 # repo:strapdata/elassandra
     - 191442206 # repo:kashirin-alex/swc-db


### PR DESCRIPTION
Fix #1093

data: update database label data (total 206) refer to DB-Engines in Dec, 2022. Filter conditions:  `Rankings in the DB-Engines Rankings table in Dec, 2022` and `has open source license` and `has repository on GitHub`. 