### PR TITLE
data: Update dbms labeled data incrementally based on DB-Engines in Jan, 2023.

### DIFF
--- a/labeled_data/technology/database/key_value.yml
+++ b/labeled_data/technology/database/key_value.yml
@@ -55,3 +55,4 @@ data:
     - 33275300 # repo:cachelot/cachelot
     - 96580430 # repo:datajaguar/jaguardb
     - 278320002 # repo:estraier/tkrzw
+    - 276042304 # repo:skytable/skytable


### PR DESCRIPTION
Fix https://github.com/X-lab2017/open-digger/issues/1136

data: Update dbms labeled data incrementally based on DB-Engines in Jan, 2023. Filter conditions: `Rankings in the DB-Engines Rankings table in Jan, 2023` and `has repository on GitHub` and `not labled yet`.