### PR TITLE
feat: add new standard to time range metrics

### DIFF
--- a/src/metrics/basic.ts
+++ b/src/metrics/basic.ts
@@ -41,6 +41,18 @@ export const getMergedConfig = (config: any): QueryConfig => {
   return merge(defaultConfig, config);
 }
 
+export interface TimeDurationOption {
+  unit: 'week' | 'day' | 'hour' | 'minute';
+  thresholds: number[];
+  sortBy: 'avg' | 'levels' | 'quantile_0' | 'quantile_1' | 'quantile_2' | 'quantile_3' | 'quantile_4'
+}
+
+export const timeDurationConstants = {
+  unitArray: ['week', 'day', 'hour', 'minute'],
+  sortByArray: ['avg', 'levels', 'quantile_0', 'quantile_1', 'quantile_2', 'quantile_3', 'quantile_4'],
+  quantileArray: [...Array(5).keys()],
+};
+
 export const forEveryMonthByConfig = async (config: QueryConfig, func: (y: number, m: number) => Promise<any>) => {
   return forEveryMonth(config.startYear, config.startMonth, config.endYear, config.endMonth, func);
 }

--- a/src/metrics/chaoss.ts
+++ b/src/metrics/chaoss.ts
@@ -7,7 +7,9 @@ import {
   getOutterOrderAndLimit,
   getRepoWhereClauseForClickhouse,
   getTimeRangeWhereClauseForClickhouse,
-  QueryConfig
+  timeDurationConstants,
+  QueryConfig,
+  TimeDurationOption
 } from "./basic";
 import * as clickhouse from '../db/clickhouse';
 import { basicActivitySqlComponent } from "./indices";
@@ -222,10 +224,8 @@ ${getOutterOrderAndLimit(config, 'issues_close_count')}`;
   });
 };
 
-interface IssueResolutionDurationOptions {
+interface IssueResolutionDurationOptions extends TimeDurationOption {
   by: 'open' | 'close';
-  type: 'avg' | 'median';
-  unit: 'week' | 'day' | 'hour' | 'minute';
 }
 export const chaossIssueResolutionDuration = async (config: QueryConfig<IssueResolutionDurationOptions>) => {
   config = getMergedConfig(config);
@@ -236,21 +236,27 @@ export const chaossIssueResolutionDuration = async (config: QueryConfig<IssueRes
   const endDate = new Date(`${config.endYear}-${config.endMonth}-1`);
   endDate.setMonth(config.endMonth);  // find next month
 
-  let by = filterEnumType(config.options?.by, ['open', 'close'], 'open');
+  const by = filterEnumType(config.options?.by, ['open', 'close'], 'open');
   const byCol = by === 'open' ? 'opened_at' : 'closed_at';
-  let type = filterEnumType(config.options?.type, ['avg', 'median'], 'avg');
-  let unit = filterEnumType(config.options?.unit, ['week', 'day', 'hour', 'minute'], 'day');
+  const unit = filterEnumType(config.options?.unit, timeDurationConstants.unitArray, 'day');
+  const thresholds = config.options?.thresholds ?? [3, 7, 15];
+  const ranges = [...thresholds, -1];
+  const sortBy = filterEnumType(config.options?.sortBy, timeDurationConstants.sortByArray, 'avg');
 
   const sql = `
 SELECT
   id,
-  argMax(name, time) AS name,
-  ${getGroupArrayInsertAtClauseForClickhouse(config, { key: `resolution_duration`, defaultValue: 'NaN' })}
+  argMax(name, time),
+  ${getGroupArrayInsertAtClauseForClickhouse(config, { key: `avg`, defaultValue: 'NaN' })},
+  ${getGroupArrayInsertAtClauseForClickhouse(config, { key: 'levels', value: 'resolution_levels', defaultValue: `[${ranges.map(_ => `0`).join(',')}]`, noPrecision: true })},
+  ${timeDurationConstants.quantileArray.map(q => getGroupArrayInsertAtClauseForClickhouse(config, { key: `quantile_${q}`, defaultValue: 'NaN' })).join(',')}
 FROM
 (
   SELECT
     ${getGroupTimeAndIdClauseForClickhouse(config, 'repo', byCol)},
-    ${type}(dateDiff('${unit}', opened_at, closed_at)) AS resolution_duration
+    avg(resolution_duration) AS avg,
+    ${timeDurationConstants.quantileArray.map(q => `quantile(${q / 4})(resolution_duration) AS quantile_${q}`).join(',')},
+    [${ranges.map((_t, i) => `countIf(resolution_level = ${i})`).join(',')}] AS resolution_levels
   FROM
   (
     SELECT
@@ -261,7 +267,9 @@ FROM
       issue_number,
       argMaxIf(action, created_at, action IN ('opened', 'closed' , 'reopened')) AS last_action,
       argMax(issue_created_at,created_at) AS opened_at,
-      maxIf(created_at, action = 'closed') AS closed_at
+      maxIf(created_at, action = 'closed') AS closed_at,
+      dateDiff('${unit}', opened_at, closed_at) AS resolution_duration,
+      multiIf(${thresholds.map((t, i) => `resolution_duration <= ${t}, ${i}`)}, ${thresholds.length}) AS resolution_level
     FROM gh_events
     WHERE ${whereClauses.join(' AND ')}
     GROUP BY repo_id, org_id, issue_number
@@ -271,43 +279,50 @@ FROM
   ${getInnerOrderAndLimit(config, 'resolution_duration')}
 )
 GROUP BY id
-${getOutterOrderAndLimit(config, 'resolution_duration')}`;
+${getOutterOrderAndLimit(config, sortBy, sortBy === 'levels' ? 1 : undefined)}`;
 
   const result: any = await clickhouse.query(sql);
   return result.map(row => {
-    const [id, name, resolution_duration] = row;
+    const [id, name, avg, levels, quantile_0, quantile_1, quantile_2, quantile_3, quantile_4] = row;
     return {
       id,
       name,
-      resolution_duration,
-    }
+      avg,
+      levels,
+      quantile_0,
+      quantile_1,
+      quantile_2,
+      quantile_3,
+      quantile_4,
+    };
   });
 };
 
-interface IssueResponseTimeOptions {
-  thresholds: number[];
-  unit: 'month' | 'week' | 'day' | 'hour' | 'minute';
-}
-export const chaossIssueResponseTime = async (config: QueryConfig<IssueResponseTimeOptions>) => {
+export const chaossIssueResponseTime = async (config: QueryConfig<TimeDurationOption>) => {
   config = getMergedConfig(config);
   const whereClauses: string[] = ["type IN ('IssueCommentEvent', 'IssuesEvent') AND actor_login NOT LIKE '%[bot]'  "];
   const repoWhereClause = await getRepoWhereClauseForClickhouse(config);
   if (repoWhereClause) whereClauses.push(repoWhereClause);
   const endDate = new Date(`${config.endYear}-${config.endMonth}-1`);
   endDate.setMonth(config.endMonth);  // find next month  
-  let thresholds = config.options?.thresholds ?? [1, 3, 7]; // 3 thredholds will separate the value to 4 ranges
-  let ranges = [...thresholds, -1]; // an array with one more element than threholds
-  let unit = filterEnumType(config.options?.unit, ['month', 'week', 'day', 'hour', 'minute'], 'day');
+  const unit = filterEnumType(config.options?.unit, timeDurationConstants.unitArray, 'day');
+  const thresholds = config.options?.thresholds ?? [3, 7, 15];
+  const ranges = [...thresholds, -1];
+  const sortBy = filterEnumType(config.options?.sortBy, timeDurationConstants.sortByArray, 'avg');
 
   const sql = `
 SELECT 
- id,
- argMax(name, time) AS name,   
- ${getGroupArrayInsertAtClauseForClickhouse(config, { key: 'issue_response_time', value: 'response_levels', defaultValue: `[${ranges.map(_ => `0`).join(',')}]`, noPrecision: true })}
+  id,
+  argMax(name, time),
+  ${getGroupArrayInsertAtClauseForClickhouse(config, { key: `avg`, defaultValue: 'NaN' })},
+  ${getGroupArrayInsertAtClauseForClickhouse(config, { key: 'levels', value: 'response_levels', defaultValue: `[${ranges.map(_ => `0`).join(',')}]`, noPrecision: true })},
+  ${timeDurationConstants.quantileArray.map(q => getGroupArrayInsertAtClauseForClickhouse(config, { key: `quantile_${q}`, defaultValue: 'NaN' })).join(',')}
 FROM
 (
   SELECT
     ${getGroupTimeAndIdClauseForClickhouse(config, 'repo', 'issue_created_at')},
+    avg(response_time) AS avg,
+    ${timeDurationConstants.quantileArray.map(q => `quantile(${q / 4})(response_time) AS quantile_${q}`).join(',')},
     [${ranges.map((_t, i) => `countIf(response_level = ${i})`).join(',')}] AS response_levels
   FROM
   (
@@ -329,19 +344,25 @@ FROM
              AND issue_created_at < toDate('${endDate.getFullYear()}-${endDate.getMonth() + 1}-1')
   )
   GROUP BY id, time
-  ${getInnerOrderAndLimit(config, 'issue_response_time', 1)}
+  ${getInnerOrderAndLimit(config, 'response_time')}
 )
 GROUP BY id
-${getOutterOrderAndLimit(config, 'issue_response_time', 1)}`;
+${getOutterOrderAndLimit(config, sortBy, sortBy === 'levels' ? 1 : undefined)}`;
 
   const result: any = await clickhouse.query(sql);
   return result.map(row => {
-    const [id, name, issue_response_time] = row;
+    const [id, name, avg, levels, quantile_0, quantile_1, quantile_2, quantile_3, quantile_4] = row;
     return {
       id,
       name,
-      issue_response_time,
-    }
+      avg,
+      levels,
+      quantile_0,
+      quantile_1,
+      quantile_2,
+      quantile_3,
+      quantile_4,
+    };
   });
 };
 
@@ -424,10 +445,8 @@ ${getOutterOrderAndLimit(config, 'change_requests_declined')}`;
   });
 };
 
-interface ChangeRequestsDurationOptions {
+interface ChangeRequestsDurationOptions extends TimeDurationOption {
   by: 'open' | 'close';
-  type: 'avg' | 'median';
-  unit: 'week' | 'day' | 'hour' | 'minute';
 }
 export const chaossChangeRequestsDuration = async (config: QueryConfig<ChangeRequestsDurationOptions>) => {
   config = getMergedConfig(config);
@@ -438,21 +457,27 @@ export const chaossChangeRequestsDuration = async (config: QueryConfig<ChangeReq
   const endDate = new Date(`${config.endYear}-${config.endMonth}-1`);
   endDate.setMonth(config.endMonth);  // find next month
 
-  let by = filterEnumType(config.options?.by, ['open', 'close'], 'open');
+  const by = filterEnumType(config.options?.by, ['open', 'close'], 'open');
   const byCol = by === 'open' ? 'opened_at' : 'closed_at';
-  let type = filterEnumType(config.options?.type, ['avg', 'median'], 'avg');
-  let unit = filterEnumType(config.options?.unit, ['week', 'day', 'hour', 'minute'], 'day');
+  const unit = filterEnumType(config.options?.unit, timeDurationConstants.unitArray, 'day');
+  const thresholds = config.options?.thresholds ?? [3, 7, 15];
+  const ranges = [...thresholds, -1];
+  const sortBy = filterEnumType(config.options?.sortBy, timeDurationConstants.sortByArray, 'avg');
 
   const sql = `
 SELECT
   id,
-  argMax(name, time) AS name,
-  ${getGroupArrayInsertAtClauseForClickhouse(config, { key: `resolution_duration`, defaultValue: 'NaN' })}
+  argMax(name, time),
+  ${getGroupArrayInsertAtClauseForClickhouse(config, { key: `avg`, defaultValue: 'NaN' })},
+  ${getGroupArrayInsertAtClauseForClickhouse(config, { key: 'levels', value: 'resolution_levels', defaultValue: `[${ranges.map(_ => `0`).join(',')}]`, noPrecision: true })},
+  ${timeDurationConstants.quantileArray.map(q => getGroupArrayInsertAtClauseForClickhouse(config, { key: `quantile_${q}`, defaultValue: 'NaN' })).join(',')}
 FROM
 (
   SELECT
     ${getGroupTimeAndIdClauseForClickhouse(config, 'repo', byCol)},
-    ${type}(dateDiff('${unit}', opened_at, closed_at)) AS resolution_duration
+    avg(resolution_duration) AS avg,
+    ${timeDurationConstants.quantileArray.map(q => `quantile(${q / 4})(resolution_duration) AS quantile_${q}`).join(',')},
+    [${ranges.map((_t, i) => `countIf(resolution_level = ${i})`).join(',')}] AS resolution_levels
   FROM
   (
     SELECT
@@ -463,7 +488,9 @@ FROM
       issue_number,
       argMaxIf(action, created_at, action IN ('opened', 'closed' , 'reopened')) AS last_action,
       argMax(issue_created_at,created_at) AS opened_at,
-      maxIf(created_at, action = 'closed') AS closed_at
+      maxIf(created_at, action = 'closed') AS closed_at,
+      dateDiff('${unit}', opened_at, closed_at) AS resolution_duration,
+      multiIf(${thresholds.map((t, i) => `resolution_duration <= ${t}, ${i}`)}, ${thresholds.length}) AS resolution_level
     FROM gh_events
     WHERE ${whereClauses.join(' AND ')}
     GROUP BY repo_id, org_id, issue_number
@@ -473,16 +500,22 @@ FROM
   ${getInnerOrderAndLimit(config, 'resolution_duration')}
 )
 GROUP BY id
-${getOutterOrderAndLimit(config, 'resolution_duration')}`;
+${getOutterOrderAndLimit(config, sortBy, sortBy === 'levels' ? 1 : undefined)}`;
 
   const result: any = await clickhouse.query(sql);
   return result.map(row => {
-    const [id, name, resolution_duration] = row;
+    const [id, name, avg, levels, quantile_0, quantile_1, quantile_2, quantile_3, quantile_4] = row;
     return {
       id,
       name,
-      resolution_duration,
-    }
+      avg,
+      levels,
+      quantile_0,
+      quantile_1,
+      quantile_2,
+      quantile_3,
+      quantile_4,
+    };
   });
 };
 

--- a/test/metrics.test.ts
+++ b/test/metrics.test.ts
@@ -3,7 +3,8 @@ const openDigger = require('../src/metrics/index');
 
 describe('Index and metric test', () => {
   // use repos under google org in 2015 to 2016
-  const commonAssert = async (func: (option: any) => Promise<any[]>, key: string, index?: number) => {
+
+  const commonAssert = async (func: (option: any) => Promise<any[]>, key: string, options?: any) => {
     const years = 2;
     const months = 24;
 
@@ -12,17 +13,19 @@ describe('Index and metric test', () => {
       startYear: 2015, endYear: 2016, startMonth: 1, endMonth: 12,
       orgIds: [1342004], order: 'DESC', limit: 3,
       groupTimeRange: 'year',
+      ...(options?.queryOptions ? options.queryOptions : {}),
     };
     let result = await func(option);
     assert.strictEqual(result.length, option.limit); // the limit works fine
     assert.strictEqual(result.every(r => r[key].length === years), true);  // the main field has correct length
     // order works fine
-    if (index !== undefined) {
-      assert.strictEqual(parseFloat(result[0][key][years - 1][index]) >= parseFloat(result[option.limit - 1][key][years - 1][index]), true);
+    if (options?.index !== undefined) {
+      assert.strictEqual(parseFloat(result[0][key][years - 1][options.index]) >= parseFloat(result[option.limit - 1][key][years - 1][options.index]), true);
     } else {
       assert.strictEqual(parseFloat(result[0][key][years - 1]) >= parseFloat(result[option.limit - 1][key][years - 1]), true);
     }
 
+    if (options?.noTotal) return;
     // month group with total order
     option.groupTimeRange = 'month';
     option.orderOption = 'total';
@@ -32,8 +35,8 @@ describe('Index and metric test', () => {
     assert.strictEqual(result.every(r => r[key].length === months), true);  // the main field has correct length
     // order works fine
     const sumFunc = (res: any, f?: any): number => res[key].map(r => parseFloat(f ? f(r) : r)).reduce((p, c) => p + c);
-    if (index !== undefined) {
-      assert.strictEqual(sumFunc(result[0], r => r[index]) <= sumFunc(result[option.limit - 1], r => r[index]), true);
+    if (options?.index !== undefined) {
+      assert.strictEqual(sumFunc(result[0], r => r[options.index]) <= sumFunc(result[option.limit - 1], r => r[options.index]), true);
     } else {
       assert.strictEqual(sumFunc(result[0]) <= sumFunc(result[option.limit - 1]), true);
     }
@@ -74,10 +77,28 @@ describe('Index and metric test', () => {
       await commonAssert(openDigger.chaossChangeRequestsDeclined, 'count');
     });
     it('issue resolution duration', async () => {
-      await commonAssert(openDigger.chaossIssueResolutionDuration, 'resolution_duration');
+      const getParams = (key: string): [() => any, string, any] =>
+        [openDigger.chaossIssueResolutionDuration, key, { noTotal: true, queryOptions: { options: { sortBy: key } } }];
+      await commonAssert(...getParams('avg'));
+      await commonAssert(...getParams('quantile_0'));
+      await commonAssert(...getParams('quantile_1'));
+      await commonAssert(...getParams('quantile_2'));
+      await commonAssert(...getParams('quantile_3'));
+      await commonAssert(...getParams('quantile_4'));
+      const p = getParams('levels');
+      await commonAssert(p[0], p[1], { index: 1, ...p[2] });
     });
     it('issue response time', async () => {
-      await commonAssert(openDigger.chaossIssueResponseTime, 'issue_response_time', 1);
+      const getParams = (key: string): [() => any, string, any] =>
+        [openDigger.chaossIssueResponseTime, key, { noTotal: true, queryOptions: { options: { sortBy: key } } }];
+      await commonAssert(...getParams('avg'));
+      await commonAssert(...getParams('quantile_0'));
+      await commonAssert(...getParams('quantile_1'));
+      await commonAssert(...getParams('quantile_2'));
+      await commonAssert(...getParams('quantile_3'));
+      await commonAssert(...getParams('quantile_4'));
+      const p = getParams('levels');
+      await commonAssert(p[0], p[1], { index: 1, ...p[2] });
     });
     it('code change lines', async () => {
       await commonAssert(openDigger.chaossCodeChangeLines, 'lines');
@@ -95,7 +116,16 @@ describe('Index and metric test', () => {
       await commonAssert(openDigger.chaossNewContributors, 'new_contributors');
     });
     it('request requests duration', async () => {
-      await commonAssert(openDigger.chaossChangeRequestsDuration, 'resolution_duration');
+      const getParams = (key: string): [() => any, string, any] =>
+        [openDigger.chaossChangeRequestsDuration, key, { noTotal: true, queryOptions: { options: { sortBy: key } } }];
+      await commonAssert(...getParams('avg'));
+      await commonAssert(...getParams('quantile_0'));
+      await commonAssert(...getParams('quantile_1'));
+      await commonAssert(...getParams('quantile_2'));
+      await commonAssert(...getParams('quantile_3'));
+      await commonAssert(...getParams('quantile_4'));
+      const p = getParams('levels');
+      await commonAssert(p[0], p[1], { index: 1, ...p[2] });
     });
     it('request requests acceptance ratio', async () => {
       await commonAssert(openDigger.chaossChangeRequestsAcceptanceRatio, 'ratio');


### PR DESCRIPTION
Signed-off-by: frank-zsy <syzhao1988@126.com>

close #1142 

Add a `TimeDurationOption` for all the time range metrics, they should all return `avg` for average, `levels` for thresholds levels and `quantile_0` to `quantile_4` which is the quantiles of the metrics. And the metrics should support order by any above field.

Also add a `noTotal` option to metrics test, since for time duration metrics, we use `NaN` for time range which has no data rather than 0, so `sum` will return `null` for the metrics which can not be compared.