### PR TITLE
metric: add change request resolution duration

### DIFF
--- a/src/metrics/chaoss.ts
+++ b/src/metrics/chaoss.ts
@@ -261,12 +261,12 @@ ${getOutterOrderAndLimit(config, 'issues_close_count')}`;
   });
 };
 
-interface IssueResolutionDurationOptions extends TimeDurationOption {
+interface ResolutionDurationOptions extends TimeDurationOption {
   by: 'open' | 'close';
 }
-export const chaossIssueResolutionDuration = async (config: QueryConfig<IssueResolutionDurationOptions>) => {
+const chaossResolutionDuration = async (config: QueryConfig<ResolutionDurationOptions>, type: 'issue' | 'change request') => {
   config = getMergedConfig(config);
-  const whereClauses: string[] = ["type = 'IssuesEvent'"];
+  const whereClauses: string[] = type === 'issue' ? ["type = 'IssuesEvent'"] : ["type = 'PullRequestEvent'"];
   const repoWhereClause = await getRepoWhereClauseForClickhouse(config);
   if (repoWhereClause) whereClauses.push(repoWhereClause);
 
@@ -334,6 +334,12 @@ ${getOutterOrderAndLimit(config, sortBy, sortBy === 'levels' ? 1 : undefined)}`;
     };
   });
 };
+
+export const chaossIssueResolutionDuration = (config: QueryConfig<ResolutionDurationOptions>) =>
+  chaossResolutionDuration(config, 'issue');
+
+export const chaossChangeRequestResolutionDuration = (config: QueryConfig<ResolutionDurationOptions>) =>
+  chaossResolutionDuration(config, 'change request');
 
 export const chaossIssueResponseTime = async (config: QueryConfig<TimeDurationOption>) => {
   config = getMergedConfig(config);

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -2,7 +2,7 @@ import { getRepoOpenrank, getRepoActivity, getUserOpenrank, getUserActivity, get
 import {
   chaossCodeChangeCommits, chaossBusFactor, chaossIssuesNew, chaossIssuesClosed, chaossChangeRequestsAccepted,
   chaossChangeRequestsDeclined, chaossIssueResolutionDuration, chaossCodeChangeLines, chaossTechnicalFork,
-  chaossChangeRequests, chaossChangeRequestReviews, chaossNewContributors, chaossChangeRequestsDuration, chaossIssueResponseTime, chaossChangeRequestsAcceptanceRatio, chaossIssuesActive, chaossActiveDatesAndTimes,
+  chaossChangeRequests, chaossChangeRequestReviews, chaossNewContributors, chaossChangeRequestsDuration, chaossIssueResponseTime, chaossChangeRequestsAcceptanceRatio, chaossIssuesActive, chaossActiveDatesAndTimes, chaossChangeRequestResolutionDuration,
 } from './chaoss';
 import { repoStars, repoIssueComments, repoParticipants, userEquivalentTimeZone } from './metrics';
 import { getRelatedUsers } from './related_users';
@@ -24,6 +24,7 @@ module.exports = {
   chaossChangeRequestsAccepted: chaossChangeRequestsAccepted,
   chaossChangeRequestsDeclined: chaossChangeRequestsDeclined,
   chaossIssueResolutionDuration: chaossIssueResolutionDuration,
+  chaossChangeRequestResolutionDuration: chaossChangeRequestResolutionDuration,
   chaossIssueResponseTime: chaossIssueResponseTime,
   chaossCodeChangeLines: chaossCodeChangeLines,
   chaossTechnicalFork: chaossTechnicalFork,

--- a/src/open_digger.js
+++ b/src/open_digger.js
@@ -38,6 +38,7 @@ const openDigger = {
       changeRequestsAccepted: func.chaossChangeRequestsAccepted,
       changeRequestsDeclined: func.chaossChangeRequestsDeclined,
       issueResolutionDuration: func.chaossIssueResolutionDuration,
+      changeRequestResolutionDuration: func.chaossChangeRequestResolutionDuration,
       codeChangeLines: func.chaossCodeChangeLines,
       newContributors: func.chaossNewContributors,
       changeRequestsDuration: func.chaossChangeRequestsDuration,

--- a/test/metrics.test.ts
+++ b/test/metrics.test.ts
@@ -91,6 +91,18 @@ describe('Index and metric test', () => {
       const p = getParams('levels');
       await commonAssert(p[0], p[1], { index: 1, ...p[2] });
     });
+    it('change request resolution duration', async () => {
+      const getParams = (key: string): [() => any, string, any] =>
+        [openDigger.chaossChangeRequestResolutionDuration, key, { noTotal: true, queryOptions: { options: { sortBy: key } } }];
+      await commonAssert(...getParams('avg'));
+      await commonAssert(...getParams('quantile_0'));
+      await commonAssert(...getParams('quantile_1'));
+      await commonAssert(...getParams('quantile_2'));
+      await commonAssert(...getParams('quantile_3'));
+      await commonAssert(...getParams('quantile_4'));
+      const p = getParams('levels');
+      await commonAssert(p[0], p[1], { index: 1, ...p[2] });
+    });
     it('issue response time', async () => {
       const getParams = (key: string): [() => any, string, any] =>
         [openDigger.chaossIssueResponseTime, key, { noTotal: true, queryOptions: { options: { sortBy: key } } }];


### PR DESCRIPTION
Signed-off-by: frank-zsy <syzhao1988@126.com>

close #575 

Add a `chaossChangeRequestResolutionDuration` metric, which uses the same logic with `chaossIssueResolutionDuration` metric.