### PR TITLE
metric: add change request response time

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -3,5 +3,5 @@
     "ts"
   ],
   "require": "ts-node/register",
-  "timeout": "20000"
+  "timeout": "30000"
 }

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -2,7 +2,7 @@ import { getRepoOpenrank, getRepoActivity, getUserOpenrank, getUserActivity, get
 import {
   chaossCodeChangeCommits, chaossBusFactor, chaossIssuesNew, chaossIssuesClosed, chaossChangeRequestsAccepted,
   chaossChangeRequestsDeclined, chaossIssueResolutionDuration, chaossCodeChangeLines, chaossTechnicalFork,
-  chaossChangeRequests, chaossChangeRequestReviews, chaossNewContributors, chaossChangeRequestsDuration, chaossIssueResponseTime, chaossChangeRequestsAcceptanceRatio, chaossIssuesActive, chaossActiveDatesAndTimes, chaossChangeRequestResolutionDuration,
+  chaossChangeRequests, chaossChangeRequestReviews, chaossNewContributors, chaossChangeRequestsDuration, chaossIssueResponseTime, chaossChangeRequestsAcceptanceRatio, chaossIssuesActive, chaossActiveDatesAndTimes, chaossChangeRequestResolutionDuration, chaossChangeRequestResponseTime,
 } from './chaoss';
 import { repoStars, repoIssueComments, repoParticipants, userEquivalentTimeZone } from './metrics';
 import { getRelatedUsers } from './related_users';
@@ -26,6 +26,7 @@ module.exports = {
   chaossIssueResolutionDuration: chaossIssueResolutionDuration,
   chaossChangeRequestResolutionDuration: chaossChangeRequestResolutionDuration,
   chaossIssueResponseTime: chaossIssueResponseTime,
+  chaossChangeRequestResponseTime: chaossChangeRequestResponseTime,
   chaossCodeChangeLines: chaossCodeChangeLines,
   chaossTechnicalFork: chaossTechnicalFork,
   chaossChangeRequests: chaossChangeRequests,

--- a/src/open_digger.js
+++ b/src/open_digger.js
@@ -43,6 +43,7 @@ const openDigger = {
       newContributors: func.chaossNewContributors,
       changeRequestsDuration: func.chaossChangeRequestsDuration,
       issueResponseTime: func.chaossIssueResponseTime,
+      changeRequestResponseTime: func.chaossChangeRequestResponseTime,
       technicalFork: func.chaossTechnicalFork,
       changeRequestsAcceptanceRatio: func.chaossChangeRequestsAcceptanceRatio,
       repoActiveDatesAndTimes: func.chaossRepoActiveDatesAndTimes,

--- a/test/metrics.test.ts
+++ b/test/metrics.test.ts
@@ -115,6 +115,18 @@ describe('Index and metric test', () => {
       const p = getParams('levels');
       await commonAssert(p[0], p[1], { index: 1, ...p[2] });
     });
+    it('change request response time', async () => {
+      const getParams = (key: string): [() => any, string, any] =>
+        [openDigger.chaossChangeRequestResponseTime, key, { noTotal: true, queryOptions: { options: { sortBy: key } } }];
+      await commonAssert(...getParams('avg'));
+      await commonAssert(...getParams('quantile_0'));
+      await commonAssert(...getParams('quantile_1'));
+      await commonAssert(...getParams('quantile_2'));
+      await commonAssert(...getParams('quantile_3'));
+      await commonAssert(...getParams('quantile_4'));
+      const p = getParams('levels');
+      await commonAssert(p[0], p[1], { index: 1, ...p[2] });
+    });
     it('code change lines', async () => {
       await commonAssert(openDigger.chaossCodeChangeLines, 'lines');
     });


### PR DESCRIPTION
Signed-off-by: frank-zsy <syzhao1988@126.com>

close #574 

Add `chaossChangeRequestResponseTime` metric which reuses the logic of `chaossIssueResponseTime` metric.

Add timeout of unit test to 30s to make sure the test finishes.