### PR TITLE
metric: add chaoss issue age

### DIFF
--- a/src/metrics/basic.ts
+++ b/src/metrics/basic.ts
@@ -317,14 +317,18 @@ export const getGroupArrayInsertAtClauseForClickhouse = (config: QueryConfig, op
     })()}) AS ${option.key}`
 }
 
-export const getGroupTimeAndIdClauseForClickhouse = (config: QueryConfig, type: string = 'repo', timeCol: string = 'created_at'): string => {
+export const getGroupTimeClauseForClickhouse = (config: QueryConfig, timeCol: string = 'created_at'): string => {
   return `${(() => {
     let groupEle = '1'; // no time range, aggregate all data to a single value
     if (config.groupTimeRange === 'month') groupEle = `toStartOfMonth(${timeCol})`;
     else if (config.groupTimeRange === 'quarter') groupEle = `toStartOfQuarter(${timeCol})`;
     else if (config.groupTimeRange === 'year') groupEle = `toStartOfYear(${timeCol})`;
     return groupEle;
-  })()} AS time, ${(() => {
+  })()} AS time`;
+}
+
+export const getGroupIdClauseForClickhouse = (config: QueryConfig, type: string = 'repo') => {
+  return `${(() => {
     if (!config.groupBy) {  // group by repo'
       if (type === 'repo')
         return 'repo_id AS id, argMax(repo_name, time) AS name';

--- a/src/metrics/basic.ts
+++ b/src/metrics/basic.ts
@@ -296,16 +296,25 @@ export const getLabelGroupConditionClauseForClickhouse = (config: QueryConfig): 
 export const getGroupArrayInsertAtClauseForClickhouse = (config: QueryConfig, option: { key: string; defaultValue?: string; value?: string; noPrecision?: boolean }): string => {
   let startTime = `toDate('${config.startYear}-${config.startMonth}-1')`;
   let endTime = `toDate('${config.endYear}-${config.endMonth}-1')`;
-  return `groupArrayInsertAt(${option.defaultValue ?? 0}, toUInt32(dateDiff('${config.groupTimeRange}', ${startTime}, ${endTime})) + 1)(${(() => {
-    const name = option.value ? option.value : option.key;
-    if (config.precision > 0 && !option.noPrecision) return `ROUND(${name}, ${config.precision})`;
-    return name;
-  })()}, ${(() => {
-    if (!config.groupTimeRange) return '0';
-    if (config.groupTimeRange === 'quarter') startTime = `toStartOfQuarter(${startTime})`;
-    else if (config.groupTimeRange === 'year') startTime = `toStartOfYear(${startTime})`;
-    return `toUInt32(dateDiff('${config.groupTimeRange}', ${startTime}, time))`;
-  })()}) AS ${option.key}`
+  return `groupArrayInsertAt(
+    ${option.defaultValue ?? 0},
+    ${(() => {
+      if (config.groupTimeRange) {
+        return `toUInt32(dateDiff('${config.groupTimeRange}', ${startTime}, ${endTime})) + 1)`;
+      } else {
+        return '1)';
+      }
+    })()}(${(() => {
+      const name = option.value ? option.value : option.key;
+      if (config.precision > 0 && !option.noPrecision) return `ROUND(${name}, ${config.precision})`;
+      return name;
+    })()},
+    ${(() => {
+      if (!config.groupTimeRange) return '0';
+      if (config.groupTimeRange === 'quarter') startTime = `toStartOfQuarter(${startTime})`;
+      else if (config.groupTimeRange === 'year') startTime = `toStartOfYear(${startTime})`;
+      return `toUInt32(dateDiff('${config.groupTimeRange}', ${startTime}, time))`;
+    })()}) AS ${option.key}`
 }
 
 export const getGroupTimeAndIdClauseForClickhouse = (config: QueryConfig, type: string = 'repo', timeCol: string = 'created_at'): string => {

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -2,7 +2,7 @@ import { getRepoOpenrank, getRepoActivity, getUserOpenrank, getUserActivity, get
 import {
   chaossCodeChangeCommits, chaossBusFactor, chaossIssuesNew, chaossIssuesClosed, chaossChangeRequestsAccepted,
   chaossChangeRequestsDeclined, chaossIssueResolutionDuration, chaossCodeChangeLines, chaossTechnicalFork,
-  chaossChangeRequests, chaossChangeRequestReviews, chaossNewContributors, chaossChangeRequestsDuration, chaossIssueResponseTime, chaossChangeRequestsAcceptanceRatio, chaossIssuesActive, chaossActiveDatesAndTimes, chaossChangeRequestResolutionDuration, chaossChangeRequestResponseTime,
+  chaossChangeRequests, chaossChangeRequestReviews, chaossNewContributors, chaossChangeRequestsDuration, chaossIssueResponseTime, chaossChangeRequestsAcceptanceRatio, chaossIssuesActive, chaossActiveDatesAndTimes, chaossChangeRequestResolutionDuration, chaossChangeRequestResponseTime, chaossIssueAge, chassChangeRequestAge,
 } from './chaoss';
 import { repoStars, repoIssueComments, repoParticipants, userEquivalentTimeZone } from './metrics';
 import { getRelatedUsers } from './related_users';
@@ -27,6 +27,8 @@ module.exports = {
   chaossChangeRequestResolutionDuration: chaossChangeRequestResolutionDuration,
   chaossIssueResponseTime: chaossIssueResponseTime,
   chaossChangeRequestResponseTime: chaossChangeRequestResponseTime,
+  chaossIssueAge: chaossIssueAge,
+  chaossChangeRequestAge: chassChangeRequestAge,
   chaossCodeChangeLines: chaossCodeChangeLines,
   chaossTechnicalFork: chaossTechnicalFork,
   chaossChangeRequests: chaossChangeRequests,

--- a/src/metrics/indices.ts
+++ b/src/metrics/indices.ts
@@ -5,7 +5,8 @@ import {
   getUserWhereClauseForClickhouse,
   getTimeRangeWhereClauseForClickhouse,
   getGroupArrayInsertAtClauseForClickhouse,
-  getGroupTimeAndIdClauseForClickhouse,
+  getGroupTimeClauseForClickhouse,
+  getGroupIdClauseForClickhouse,
   getInnerOrderAndLimit,
   getOutterOrderAndLimit
 } from './basic';
@@ -33,7 +34,8 @@ SELECT
 FROM
 (
   SELECT
-    ${getGroupTimeAndIdClauseForClickhouse(config, 'repo')},
+    ${getGroupTimeClauseForClickhouse(config)},
+    ${getGroupIdClauseForClickhouse(config)},
     SUM(openrank) AS openrank
   FROM gh_repo_openrank
   WHERE ${whereClause.join(' AND ')}
@@ -70,7 +72,8 @@ SELECT
 FROM
 (
   SELECT
-    ${getGroupTimeAndIdClauseForClickhouse(config, 'user')},
+    ${getGroupTimeClauseForClickhouse(config)},
+    ${getGroupIdClauseForClickhouse(config, 'user')},
     SUM(openrank) AS openrank
   FROM gh_user_openrank
   WHERE ${whereClause.join(' AND ')}
@@ -124,7 +127,8 @@ SELECT
 FROM
 (
   SELECT
-    ${getGroupTimeAndIdClauseForClickhouse(config, 'repo', 'month')},
+    ${getGroupTimeClauseForClickhouse(config, 'month')},
+    ${getGroupIdClauseForClickhouse(config)},
     ROUND(SUM(activity), 2) AS activity,
     COUNT(actor_id) AS participants,
     SUM(issue_comment) AS issue_comment,
@@ -187,7 +191,8 @@ SELECT
 FROM
 (
   SELECT
-    ${getGroupTimeAndIdClauseForClickhouse(config, 'actor', 'month')},
+    ${getGroupTimeClauseForClickhouse(config, 'month')},
+    ${getGroupIdClauseForClickhouse(config)},
     ROUND(SUM(activity), 2) AS activity,
     SUM(issue_comment) AS issue_comment,
     SUM(open_issue) AS open_issue,
@@ -242,7 +247,8 @@ SELECT
 FROM
 (
   SELECT
-    ${getGroupTimeAndIdClauseForClickhouse(config)},
+    ${getGroupTimeClauseForClickhouse(config)},
+    ${getGroupIdClauseForClickhouse(config)},
     countIf(type='WatchEvent') AS stars,
     countIf(type='ForkEvent') AS forks,
     stars + 2 * forks AS attention

--- a/src/metrics/metrics.ts
+++ b/src/metrics/metrics.ts
@@ -1,6 +1,7 @@
 import {
   getGroupArrayInsertAtClauseForClickhouse,
-  getGroupTimeAndIdClauseForClickhouse,
+  getGroupTimeClauseForClickhouse,
+  getGroupIdClauseForClickhouse,
   getInnerOrderAndLimit,
   getMergedConfig,
   getOutterOrderAndLimit,
@@ -26,7 +27,8 @@ SELECT
 FROM
 (
   SELECT
-    ${getGroupTimeAndIdClauseForClickhouse(config, 'repo')},
+    ${getGroupTimeClauseForClickhouse(config)},
+    ${getGroupIdClauseForClickhouse(config)},
     COUNT() AS count
   FROM gh_events
   WHERE ${whereClauses.join(' AND ')}
@@ -62,7 +64,8 @@ SELECT
 FROM
 (
   SELECT
-    ${getGroupTimeAndIdClauseForClickhouse(config, 'repo')},
+    ${getGroupTimeClauseForClickhouse(config)},
+    ${getGroupIdClauseForClickhouse(config)},
     COUNT() AS count
   FROM gh_events
   WHERE ${whereClauses.join(' AND ')}
@@ -98,7 +101,8 @@ SELECT
 FROM
 (
   SELECT
-    ${getGroupTimeAndIdClauseForClickhouse(config, 'repo')},
+    ${getGroupTimeClauseForClickhouse(config)},
+    ${getGroupIdClauseForClickhouse(config)},
     COUNT(DISTINCT actor_id) AS count
   FROM gh_events
   WHERE ${whereClauses.join(' AND ')}
@@ -158,7 +162,8 @@ FROM
   FROM
   (
     SELECT
-      ${getGroupTimeAndIdClauseForClickhouse(config, 'user')},
+      ${getGroupTimeClauseForClickhouse(config)},
+    ${getGroupIdClauseForClickhouse(config, 'user')},
       toHour(created_at) AS hour,
       COUNT() AS count
     FROM gh_events

--- a/src/open_digger.js
+++ b/src/open_digger.js
@@ -48,6 +48,8 @@ const openDigger = {
       changeRequestsAcceptanceRatio: func.chaossChangeRequestsAcceptanceRatio,
       repoActiveDatesAndTimes: func.chaossRepoActiveDatesAndTimes,
       userActiveDatesAndTimes: func.chaossUserActiveDatesAndTimes,
+      issueAge: func.chaossIssueAge,
+      changeRequestAge: func.chaossChangeRequestAge,
     },
     xlab: {
       repoStars: func.repoStars,

--- a/test/metrics.test.ts
+++ b/test/metrics.test.ts
@@ -127,6 +127,30 @@ describe('Index and metric test', () => {
       const p = getParams('levels');
       await commonAssert(p[0], p[1], { index: 1, ...p[2] });
     });
+    it('issue age', async () => {
+      const getParams = (key: string): [() => any, string, any] =>
+        [openDigger.chaossIssueAge, key, { noTotal: true, queryOptions: { options: { sortBy: key } } }];
+      await commonAssert(...getParams('avg'));
+      await commonAssert(...getParams('quantile_0'));
+      await commonAssert(...getParams('quantile_1'));
+      await commonAssert(...getParams('quantile_2'));
+      await commonAssert(...getParams('quantile_3'));
+      await commonAssert(...getParams('quantile_4'));
+      const p = getParams('levels');
+      await commonAssert(p[0], p[1], { index: 1, ...p[2] });
+    });
+    it('change request age', async () => {
+      const getParams = (key: string): [() => any, string, any] =>
+        [openDigger.chaossChangeRequestAge, key, { noTotal: true, queryOptions: { options: { sortBy: key } } }];
+      await commonAssert(...getParams('avg'));
+      await commonAssert(...getParams('quantile_0'));
+      await commonAssert(...getParams('quantile_1'));
+      await commonAssert(...getParams('quantile_2'));
+      await commonAssert(...getParams('quantile_3'));
+      await commonAssert(...getParams('quantile_4'));
+      const p = getParams('levels');
+      await commonAssert(p[0], p[1], { index: 1, ...p[2] });
+    });
     it('code change lines', async () => {
       await commonAssert(openDigger.chaossCodeChangeLines, 'lines');
     });


### PR DESCRIPTION
Signed-off-by: frank-zsy <syzhao1988@126.com>

close #588 

Implement the `issue age` and `change request age` metrics.

This metric is quite tricky, right now, I do not group the metric by time range and just give the issue age metric until `endTime`.

And maybe we should have more complex and flexible unit test functions.