### PR TITLE
metric: add chaoss inactive contributor

### DIFF
--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -2,7 +2,7 @@ import { getRepoOpenrank, getRepoActivity, getUserOpenrank, getUserActivity, get
 import {
   chaossCodeChangeCommits, chaossBusFactor, chaossIssuesNew, chaossIssuesClosed, chaossChangeRequestsAccepted,
   chaossChangeRequestsDeclined, chaossIssueResolutionDuration, chaossCodeChangeLines, chaossTechnicalFork,
-  chaossChangeRequests, chaossChangeRequestReviews, chaossNewContributors, chaossChangeRequestsDuration, chaossIssueResponseTime, chaossChangeRequestsAcceptanceRatio, chaossIssuesActive, chaossActiveDatesAndTimes, chaossChangeRequestResolutionDuration, chaossChangeRequestResponseTime, chaossIssueAge, chassChangeRequestAge,
+  chaossChangeRequests, chaossChangeRequestReviews, chaossNewContributors, chaossChangeRequestsDuration, chaossIssueResponseTime, chaossChangeRequestsAcceptanceRatio, chaossIssuesActive, chaossActiveDatesAndTimes, chaossChangeRequestResolutionDuration, chaossChangeRequestResponseTime, chaossIssueAge, chassChangeRequestAge, chaossInactiveContributors,
 } from './chaoss';
 import { repoStars, repoIssueComments, repoParticipants, userEquivalentTimeZone } from './metrics';
 import { getRelatedUsers } from './related_users';
@@ -38,6 +38,7 @@ module.exports = {
   chaossChangeRequestsAcceptanceRatio: chaossChangeRequestsAcceptanceRatio,
   chaossRepoActiveDatesAndTimes: config => chaossActiveDatesAndTimes(config, 'repo'),
   chaossUserActiveDatesAndTimes: config => chaossActiveDatesAndTimes(config, 'user'),
+  chaossInactiveContributors: chaossInactiveContributors,
   // x-lab metrics
   repoStars: repoStars,
   repoIssueComments: repoIssueComments,

--- a/src/open_digger.js
+++ b/src/open_digger.js
@@ -50,6 +50,7 @@ const openDigger = {
       userActiveDatesAndTimes: func.chaossUserActiveDatesAndTimes,
       issueAge: func.chaossIssueAge,
       changeRequestAge: func.chaossChangeRequestAge,
+      inactiveContributors: func.chaossInactiveContributors,
     },
     xlab: {
       repoStars: func.repoStars,

--- a/test/metrics.test.ts
+++ b/test/metrics.test.ts
@@ -89,7 +89,7 @@ describe('Index and metric test', () => {
       await commonAssert(...getParams('quantile_3'));
       await commonAssert(...getParams('quantile_4'));
       const p = getParams('levels');
-      await commonAssert(p[0], p[1], { index: 1, ...p[2] });
+      await commonAssert(p[0], p[1], { index: 0, ...p[2] });
     });
     it('change request resolution duration', async () => {
       const getParams = (key: string): [() => any, string, any] =>
@@ -101,7 +101,7 @@ describe('Index and metric test', () => {
       await commonAssert(...getParams('quantile_3'));
       await commonAssert(...getParams('quantile_4'));
       const p = getParams('levels');
-      await commonAssert(p[0], p[1], { index: 1, ...p[2] });
+      await commonAssert(p[0], p[1], { index: 0, ...p[2] });
     });
     it('issue response time', async () => {
       const getParams = (key: string): [() => any, string, any] =>
@@ -113,7 +113,7 @@ describe('Index and metric test', () => {
       await commonAssert(...getParams('quantile_3'));
       await commonAssert(...getParams('quantile_4'));
       const p = getParams('levels');
-      await commonAssert(p[0], p[1], { index: 1, ...p[2] });
+      await commonAssert(p[0], p[1], { index: 0, ...p[2] });
     });
     it('change request response time', async () => {
       const getParams = (key: string): [() => any, string, any] =>
@@ -125,7 +125,7 @@ describe('Index and metric test', () => {
       await commonAssert(...getParams('quantile_3'));
       await commonAssert(...getParams('quantile_4'));
       const p = getParams('levels');
-      await commonAssert(p[0], p[1], { index: 1, ...p[2] });
+      await commonAssert(p[0], p[1], { index: 0, ...p[2] });
     });
     it('issue age', async () => {
       const getParams = (key: string): [() => any, string, any] =>
@@ -137,7 +137,7 @@ describe('Index and metric test', () => {
       await commonAssert(...getParams('quantile_3'));
       await commonAssert(...getParams('quantile_4'));
       const p = getParams('levels');
-      await commonAssert(p[0], p[1], { index: 1, ...p[2] });
+      await commonAssert(p[0], p[1], { index: 0, ...p[2] });
     });
     it('change request age', async () => {
       const getParams = (key: string): [() => any, string, any] =>
@@ -149,7 +149,7 @@ describe('Index and metric test', () => {
       await commonAssert(...getParams('quantile_3'));
       await commonAssert(...getParams('quantile_4'));
       const p = getParams('levels');
-      await commonAssert(p[0], p[1], { index: 1, ...p[2] });
+      await commonAssert(p[0], p[1], { index: 0, ...p[2] });
     });
     it('code change lines', async () => {
       await commonAssert(openDigger.chaossCodeChangeLines, 'lines');
@@ -166,6 +166,9 @@ describe('Index and metric test', () => {
     it('new contributors', async () => {
       await commonAssert(openDigger.chaossNewContributors, 'new_contributors');
     });
+    it('inactive contributors', async () => {
+      await commonAssert(openDigger.chaossInactiveContributors, 'inactive_contributors');
+    });
     it('request requests duration', async () => {
       const getParams = (key: string): [() => any, string, any] =>
         [openDigger.chaossChangeRequestsDuration, key, { noTotal: true, queryOptions: { options: { sortBy: key } } }];
@@ -176,7 +179,7 @@ describe('Index and metric test', () => {
       await commonAssert(...getParams('quantile_3'));
       await commonAssert(...getParams('quantile_4'));
       const p = getParams('levels');
-      await commonAssert(p[0], p[1], { index: 1, ...p[2] });
+      await commonAssert(p[0], p[1], { index: 0, ...p[2] });
     });
     it('request requests acceptance ratio', async () => {
       await commonAssert(openDigger.chaossChangeRequestsAcceptanceRatio, 'ratio');


### PR DESCRIPTION
Signed-off-by: frank-zsy <syzhao1988@126.com>

close #591 

Inactive contributors is a very hard metric to implement, the basic logic is:

- Find out all the contributors before `endTime` for required repos and orgs.
- To each contributor, we need to get the first contribution time point and the contributions in each time range by the config, like every month or every quarter.
- Calculate the inactive contributors if the developer was contributor by end of the time range and the contributions count is smaller than the given param.
- Group all the result into arrays.

It is different from other metric that `time` column is not a group column by original data but a new column we put into just like `issue age` metric.