### PR TITLE
metric: add contributor email suffix

### DIFF
--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -4,7 +4,7 @@ import {
   chaossChangeRequestsDeclined, chaossIssueResolutionDuration, chaossCodeChangeLines, chaossTechnicalFork,
   chaossChangeRequests, chaossChangeRequestReviews, chaossNewContributors, chaossChangeRequestsDuration, chaossIssueResponseTime, chaossChangeRequestsAcceptanceRatio, chaossIssuesActive, chaossActiveDatesAndTimes, chaossChangeRequestResolutionDuration, chaossChangeRequestResponseTime, chaossIssueAge, chassChangeRequestAge, chaossInactiveContributors,
 } from './chaoss';
-import { repoStars, repoIssueComments, repoParticipants, userEquivalentTimeZone } from './metrics';
+import { repoStars, repoIssueComments, repoParticipants, userEquivalentTimeZone, contributorEmailSuffixes } from './metrics';
 import { getRelatedUsers } from './related_users';
 
 module.exports = {
@@ -44,4 +44,5 @@ module.exports = {
   repoIssueComments: repoIssueComments,
   repoParticipants: repoParticipants,
   userEquivalentTimeZone: userEquivalentTimeZone,
+  contributorEmailSuffixes: contributorEmailSuffixes
 };

--- a/src/open_digger.js
+++ b/src/open_digger.js
@@ -56,6 +56,7 @@ const openDigger = {
       repoStars: func.repoStars,
       repoParticipants: func.repoParticipants,
       userEquivalentTimeZone: func.userEquivalentTimeZone,
+      contributorEmailSuffixes: func.contributorEmailSuffixes,
     },
   },
   relation: {

--- a/test/metrics.test.ts
+++ b/test/metrics.test.ts
@@ -191,7 +191,18 @@ describe('Index and metric test', () => {
         groupTimeRange: 'quarter', groupBy: 'org',
       };
       const result = await openDigger.contributorEmailSuffixes(option);
-      assert.strictEqual(result.length > 0, true);
+      const checkResult =
+        result.length > 0 &&  // returns result as array
+        result[0].suffixes.every(q => // for every suffixes in every quarter
+          Array.isArray(q) && // returns array for every quarter
+          q.every(i =>
+            Array.isArray(i) && // is an array
+            i.length === 2 && // array length is 2
+            typeof i[0] === 'string' && // first element is string, which is suffix
+            typeof parseInt(i[1]) === 'number'  // second element which is count can be parsed as integer
+          )
+        );
+      assert.strictEqual(checkResult, true);
     });
   });
 });

--- a/test/metrics.test.ts
+++ b/test/metrics.test.ts
@@ -184,5 +184,14 @@ describe('Index and metric test', () => {
     it('request requests acceptance ratio', async () => {
       await commonAssert(openDigger.chaossChangeRequestsAcceptanceRatio, 'ratio');
     });
+    it('contributor email suffixes', async () => {
+      const option: any = {
+        startYear: 2015, endYear: 2016, startMonth: 1, endMonth: 12,
+        orgIds: [1342004], order: 'DESC', limit: 3,
+        groupTimeRange: 'quarter', groupBy: 'org',
+      };
+      const result = await openDigger.contributorEmailSuffixes(option);
+      assert.strictEqual(result.length > 0, true);
+    });
   });
 });


### PR DESCRIPTION
Signed-off-by: frank-zsy <syzhao1988@126.com>

close #878

In this PR, I implement a metric called `contributor email suffixes` which returns the contributors email suffix statistical results by commit email and author.

The result is always sorted by suffix count and there is no other sort or limit function for this metric since it is not quite reasonable to sort or limit the result. That's why the test is quite simple which just makes sure that the metric returns data.