### PR TITLE
feat: export more metrics to OSS

### DIFF
--- a/src/cron/tasks/monthly_export.ts
+++ b/src/cron/tasks/monthly_export.ts
@@ -3,11 +3,11 @@ import { join } from 'path';
 import { Task } from '..';
 import { query, queryStream } from '../../db/clickhouse';
 import { getRepoActivity, getRepoOpenrank, getUserActivity, getUserOpenrank, getAttention } from '../../metrics/indices';
-import { forEveryMonthByConfig } from '../../metrics/basic';
+import { forEveryMonthByConfig, timeDurationConstants } from '../../metrics/basic';
 import { waitFor } from '../../utils';
 import getConfig from '../../config';
-import { chaossBusFactor, chaossChangeRequestReviews, chaossChangeRequests, chaossChangeRequestsAccepted, chaossCodeChangeLines, chaossIssuesClosed, chaossIssuesNew, chaossTechnicalFork } from '../../metrics/chaoss';
-import { repoIssueComments, repoParticipants, repoStars } from '../../metrics/metrics';
+import { chaossActiveDatesAndTimes, chaossBusFactor, chaossChangeRequestAge, chaossChangeRequestResolutionDuration, chaossChangeRequestResponseTime, chaossChangeRequestReviews, chaossChangeRequests, chaossChangeRequestsAccepted, chaossCodeChangeLines, chaossInactiveContributors, chaossIssueAge, chaossIssueResolutionDuration, chaossIssueResponseTime, chaossIssuesAndChangeRequestActive, chaossIssuesClosed, chaossIssuesNew, chaossNewContributors, chaossTechnicalFork } from '../../metrics/chaoss';
+import { contributorEmailSuffixes, repoIssueComments, repoParticipants, repoStars } from '../../metrics/metrics';
 import { getLabelData } from '../../label_data_utils';
 
 const task: Task = {
@@ -98,36 +98,32 @@ const task: Task = {
     const startYear = 2015, startMonth = 1, endYear = date.getFullYear(), endMonth = date.getMonth() + 1;
     const exportBasePath = join(config.export.path, 'github');
 
-    const processMetric = async (func: (option: any) => Promise<any>, option: any, fields: string[] | string[][], disableDataLoss: boolean = false) => {
+    const processMetric = async (func: (option: any) => Promise<any>, option: any, fields: Field | Field[]) => {
       const result: any[] = await func(option);
       for (const row of result) {
         const name = row.name;
         if (!existsSync(join(exportBasePath, name))) {
           mkdirSync(join(exportBasePath, name), { recursive: true });
         }
+        if (!Array.isArray(fields)) fields = [fields];
         for (let field of fields) {
-          let outputField = field;
-          if (Array.isArray(field)) {
-            outputField = field[1];
-            field = field[0];
-          }
-          const dataArr = row[field];
+          const dataArr = row[field.sourceKey];
           if (!dataArr) {
             console.log(`Can not find field ${field}`);
             continue;
           }
-          const exportPath = join(exportBasePath, name, outputField + '.json');
+          const exportPath = join(exportBasePath, name, field.targetKey + '.json');
           const content: any = {};
           let index = 0;
           await forEveryMonthByConfig(option, async (y, m) => {
             if (dataArr.length <= index) return;
             const key = `${y}-${m.toString().padStart(2, '0')}`;
-            const ele = parseFloat(dataArr[index++]);
-            if (ele !== 0) content[key] = ele;
+            const ele = field.parser(dataArr[index++]);
+            if (!field.isDefaultValue(ele)) content[key] = ele;
           });
-          if (!disableDataLoss && option.groupTimeRange === 'month' && content['2021-10']) {
+          if (!field.disableDataLoss && option.groupTimeRange === 'month' && content['2021-10']) {
             // reason: GHArchive had a data service failure about 2 weeks in 2021.10
-            // https://github.com/igrigorik/gharchive.org/issues/232#issuecomment-678798777
+            // https://github.com/igrigorik/gharchive.org/issues/261
             // handle data loss in 2021.10 only when generate data by month
             content['2021-10-raw'] = content['2021-10'];
             const arr = ['2021-08', '2021-09', '2021-11', '2021-12'].map(m => content[m]);
@@ -145,54 +141,116 @@ const task: Task = {
     };
 
     const option: any = { startYear, startMonth, endYear, endMonth, limit: -1, groupTimeRange: 'month' };
+    interface Field {
+      sourceKey: string;
+      targetKey: string;
+      isDefaultValue: (i: any) => boolean;
+      disableDataLoss: boolean;
+      parser: (i: any) => any;
+    };
+    const getField = (sourceKey: string, options?: Partial<Field>): Field => {
+      return {
+        sourceKey,
+        targetKey: options?.targetKey ?? sourceKey,
+        isDefaultValue: options?.isDefaultValue ?? (i => i === 0),
+        disableDataLoss: options?.disableDataLoss ?? false,
+        parser: options?.parser ?? parseFloat,
+      }
+    };
+    const arrayFieldOption: Partial<Field> = {
+      isDefaultValue: i => Array.isArray(i) && i.length === 0,
+      disableDataLoss: true,
+      parser: i => i,
+    };
+    const getDurationFields = (prefix: string): Field[] => timeDurationConstants.sortByArray.map(k => {
+      return getField(k, {
+        targetKey: `${prefix}_${k}`,
+        ...(k === 'levels' ? {
+          ...arrayFieldOption,
+          parser: i => i.map(v => parseFloat(v)),
+        } : {
+          isDefaultValue: i => Number.isNaN(i),
+          disableDataLoss: true,
+        }),
+      });
+    });
 
+    console.log('Start to process repo export task.');
     const repoPartitions = await getPartition('Repo');
     for (let i = 0; i < repoPartitions.length; i++) {
       const { min, max } = repoPartitions[i];
       option.whereClause = `repo_id BETWEEN ${min} AND ${max} AND repo_id IN (SELECT id FROM ${exportRepoTableName})`;
       // [X-lab index] repo activity
-      await processMetric(getRepoActivity, option, ['activity']);
+      await processMetric(getRepoActivity, option, getField('activity'));
       // [X-lab index] repo openrank
-      await processMetric(getRepoOpenrank, option, ['openrank']);
+      await processMetric(getRepoOpenrank, option, getField('openrank'));
       // [X-lab index] repo attention
-      await processMetric(getAttention, option, ['attention']);
+      await processMetric(getAttention, option, getField('attention'));
       // [CHAOSS metric] repo technical fork
-      await processMetric(chaossTechnicalFork, option, [['count', 'technical_fork']]);
+      await processMetric(chaossTechnicalFork, option, getField('count', { targetKey: 'technical_fork' }));
       // [X-lab metric] repo stars
-      await processMetric(repoStars, option, [['count', 'stars']]);
+      await processMetric(repoStars, option, getField('count', { targetKey: 'stars' }));
       // [CHAOSS metric] repo issues new
-      await processMetric(chaossIssuesNew, option, [['count', 'issues_new']]);
+      await processMetric(chaossIssuesNew, option, getField('count', { targetKey: 'issues_new' }));
       // [CHAOSS metric] repo issues closed
-      await processMetric(chaossIssuesClosed, option, [['count', 'issues_closed']]);
+      await processMetric(chaossIssuesClosed, option, getField('count', { targetKey: 'issues_closed' }));
       // [CHAOSS metric] repo code changes lines
-      await processMetric(chaossCodeChangeLines, { ...option, options: { by: 'add' } }, [['lines', 'code_change_lines_add']], true);
-      await processMetric(chaossCodeChangeLines, { ...option, options: { by: 'remove' } }, [['lines', 'code_change_lines_remove']], true);
-      await processMetric(chaossCodeChangeLines, { ...option, options: { by: 'sum' } }, [['lines', 'code_change_lines_sum']], true);
+      await processMetric(chaossCodeChangeLines, { ...option, options: { by: 'add' } }, getField('lines',
+        { targetKey: 'code_change_lines_add', disableDataLoss: true, }));
+      await processMetric(chaossCodeChangeLines, { ...option, options: { by: 'remove' } }, getField('lines',
+        { targetKey: 'code_change_lines_remove', disableDataLoss: true, }));
+      await processMetric(chaossCodeChangeLines, { ...option, options: { by: 'sum' } }, getField('lines',
+        { targetKey: 'code_change_lines_sum', disableDataLoss: true, }));
       // [CHAOSS metric] repo change requests
-      await processMetric(chaossChangeRequests, option, [['count', 'change_requests']]);
+      await processMetric(chaossChangeRequests, option, getField('count', { targetKey: 'change_requests' }));
       // [CHAOSS metric] repo change requests accepted
-      await processMetric(chaossChangeRequestsAccepted, option, [['count', 'change_requests_accepted']]);
+      await processMetric(chaossChangeRequestsAccepted, option, getField('count', { targetKey: 'change_requests_accepted' }));
       // [X-lab metric] repo issue comments
-      await processMetric(repoIssueComments, option, [['count', 'issue_comments']]);
+      await processMetric(repoIssueComments, option, getField('count', { targetKey: 'issue_comments' }));
       // [CHAOSS metric] repo chagne request reviews
-      await processMetric(chaossChangeRequestReviews, option, [['count', 'change_requests_reviews']]);
+      await processMetric(chaossChangeRequestReviews, option, getField('count', { targetKey: 'change_requests_reviews' }));
       // [X-lab metric] repo participants
-      await processMetric(repoParticipants, option, [['count', 'participants']]);
+      await processMetric(repoParticipants, option, getField('count', { targetKey: 'participants' }));
       // [CHAOSS] bus factor
-      await processMetric(chaossBusFactor, option, ['bus_factor']);
+      await processMetric(chaossBusFactor, option, [getField('bus_factor'), getField('detail',
+        { targetKey: 'bus_factor_detail', ...arrayFieldOption })]);
+      // [CHAOSS] issues active
+      await processMetric(chaossIssuesAndChangeRequestActive, option, getField('count', { targetKey: 'issues_and_change_request_active' }));
+      // [CHAOSS] new contributors
+      await processMetric(chaossNewContributors, option, [getField('new_contributors'), getField('detail', { targetKey: 'new_contributors_detail', ...arrayFieldOption })]);
+      // [CHAOSS] inactive contributors
+      await processMetric(chaossInactiveContributors, option, getField('inactive_contributors'));
+      // [CHAOSS] active dates and times
+      await processMetric(c => chaossActiveDatesAndTimes(c, 'repo'), { ...option, options: { normalize: 10 } },
+        getField('count', { targetKey: 'active_dates_and_times', ...arrayFieldOption }));
+      // [X-lab] contributor email suffixes
+      await processMetric(contributorEmailSuffixes, option, getField('suffixes', { targetKey: 'contributor_email_suffixes', ...arrayFieldOption }));
+      // time duration related
+      // [CHAOSS] resolution duration / close time
+      await processMetric(chaossIssueResolutionDuration, option, getDurationFields('issue_resolution_duration'));
+      await processMetric(chaossChangeRequestResolutionDuration, option, getDurationFields('change_request_resolution_duration'));
+      // [CHAOSS] first response time
+      await processMetric(chaossIssueResponseTime, option, getDurationFields('issue_response_time'));
+      await processMetric(chaossChangeRequestResponseTime, option, getDurationFields('change_request_response_time'));
+      // [CHAOSS] age
+      await processMetric(chaossIssueAge, option, getDurationFields('issue_age'));
+      await processMetric(chaossChangeRequestAge, option, getDurationFields('change_request_age'));
       console.log(`Process repo for round ${i} done.`);
     }
+    console.log('Process repo export task done.');
 
+    console.log('Start to process user export task.');
     const userPartitions = await getPartition('User');
     for (let i = 0; i < userPartitions.length; i++) {
       const { min, max } = userPartitions[i];
       option.whereClause = `actor_id BETWEEN ${min} AND ${max} AND actor_id IN (SELECT id FROM ${exportUserTableName})`;
       // user activity
-      await processMetric(getUserActivity, option, ['activity', 'open_issue', 'issue_comment', 'open_pull', 'merged_pull', 'review_comment']);
+      await processMetric(getUserActivity, option, ['activity', 'open_issue', 'issue_comment', 'open_pull', 'merged_pull', 'review_comment'].map(f => getField(f)));
       // user openrank
-      await processMetric(getUserOpenrank, option, ['openrank']);
+      await processMetric(getUserOpenrank, option, getField('openrank'));
       console.log(`Process user for round ${i} done.`);
     }
+    console.log('Process user export task done.');
   }
 };
 

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -2,7 +2,7 @@ import { getRepoOpenrank, getRepoActivity, getUserOpenrank, getUserActivity, get
 import {
   chaossCodeChangeCommits, chaossBusFactor, chaossIssuesNew, chaossIssuesClosed, chaossChangeRequestsAccepted,
   chaossChangeRequestsDeclined, chaossIssueResolutionDuration, chaossCodeChangeLines, chaossTechnicalFork,
-  chaossChangeRequests, chaossChangeRequestReviews, chaossNewContributors, chaossChangeRequestsDuration, chaossIssueResponseTime, chaossChangeRequestsAcceptanceRatio, chaossIssuesActive, chaossActiveDatesAndTimes, chaossChangeRequestResolutionDuration, chaossChangeRequestResponseTime, chaossIssueAge, chassChangeRequestAge, chaossInactiveContributors,
+  chaossChangeRequests, chaossChangeRequestReviews, chaossNewContributors, chaossChangeRequestsDuration, chaossIssueResponseTime, chaossChangeRequestsAcceptanceRatio, chaossIssuesAndChangeRequestActive, chaossActiveDatesAndTimes, chaossChangeRequestResolutionDuration, chaossChangeRequestResponseTime, chaossIssueAge, chaossChangeRequestAge, chaossInactiveContributors,
 } from './chaoss';
 import { repoStars, repoIssueComments, repoParticipants, userEquivalentTimeZone, contributorEmailSuffixes } from './metrics';
 import { getRelatedUsers } from './related_users';
@@ -18,7 +18,7 @@ module.exports = {
   // chaoss metrics
   chaossCodeChangeCommits: chaossCodeChangeCommits,
   chaossIssuesNew: chaossIssuesNew,
-  chaossIssuesActive: chaossIssuesActive,
+  chaossIssuesAndChangeRequestActive: chaossIssuesAndChangeRequestActive,
   chaossIssuesClosed: chaossIssuesClosed,
   chaossBusFactor: chaossBusFactor,
   chaossChangeRequestsAccepted: chaossChangeRequestsAccepted,
@@ -28,7 +28,7 @@ module.exports = {
   chaossIssueResponseTime: chaossIssueResponseTime,
   chaossChangeRequestResponseTime: chaossChangeRequestResponseTime,
   chaossIssueAge: chaossIssueAge,
-  chaossChangeRequestAge: chassChangeRequestAge,
+  chaossChangeRequestAge: chaossChangeRequestAge,
   chaossCodeChangeLines: chaossCodeChangeLines,
   chaossTechnicalFork: chaossTechnicalFork,
   chaossChangeRequests: chaossChangeRequests,

--- a/src/metrics/indices.ts
+++ b/src/metrics/indices.ts
@@ -192,7 +192,7 @@ FROM
 (
   SELECT
     ${getGroupTimeClauseForClickhouse(config, 'month')},
-    ${getGroupIdClauseForClickhouse(config)},
+    ${getGroupIdClauseForClickhouse(config, 'user')},
     ROUND(SUM(activity), 2) AS activity,
     SUM(issue_comment) AS issue_comment,
     SUM(open_issue) AS open_issue,

--- a/src/open_digger.js
+++ b/src/open_digger.js
@@ -32,7 +32,7 @@ const openDigger = {
     chaoss: {
       codeChangeCommits: func.chaossCodeChangeCommits,
       issuesNew: func.chaossIssuesNew,
-      issuesActive: func.chaossIssuesActive,
+      issuesAndChangeRequestActive: func.chaossIssuesAndChangeRequestActive,
       issuesClosed: func.chaossIssuesClosed,
       busFactor: func.chaossBusFactor,
       changeRequestsAccepted: func.chaossChangeRequestsAccepted,

--- a/test/metrics.test.ts
+++ b/test/metrics.test.ts
@@ -65,7 +65,7 @@ describe('Index and metric test', () => {
       await commonAssert(openDigger.chaossIssuesNew, 'count');
     });
     it('issues active', async () => {
-      await commonAssert(openDigger.chaossIssuesActive, 'count');
+      await commonAssert(openDigger.chaossIssuesAndChangeRequestActive, 'count');
     });
     it('issues closed', async () => {
       await commonAssert(openDigger.chaossIssuesClosed, 'count');


### PR DESCRIPTION
Signed-off-by: frank-zsy <syzhao1988@126.com>

close #1160 

This PR add more metrics into monthly export task, and also fixes some bugs in metrics implementation, includes:

- Change `chaossIssuesActive` to `chaossIssuesAndChangeRequestActive` metric, since we can not easily distinguish issues and PRs in events log when type is `IssueCommentEvent`.
- Change all default value for time duration levels to `[]` rather than filling with 0 elements.
- Change age related metrics have bugs before, fix the bug and verified by OpenDigger data.