### PR TITLE
fix: fix bug for no group time range

### DIFF
--- a/src/metrics/basic.ts
+++ b/src/metrics/basic.ts
@@ -323,7 +323,7 @@ export const getGroupArrayInsertAtClauseForClickhouse = (config: QueryConfig, op
 
 export const getGroupTimeClauseForClickhouse = (config: QueryConfig, timeCol: string = 'created_at'): string => {
   return `${(() => {
-    let groupEle = '1'; // no time range, aggregate all data to a single value
+    let groupEle = `dateAdd(month, 1, toDate('${config.endYear}-${config.endMonth}-1'))`; // no time range, aggregate all data to a single value, use next month of end time to make sure time compare works.
     if (config.groupTimeRange === 'month') groupEle = `toStartOfMonth(${timeCol})`;
     else if (config.groupTimeRange === 'quarter') groupEle = `toStartOfQuarter(${timeCol})`;
     else if (config.groupTimeRange === 'year') groupEle = `toStartOfYear(${timeCol})`;
@@ -335,11 +335,11 @@ export const getGroupIdClauseForClickhouse = (config: QueryConfig, type: string 
   return `${(() => {
     if (!config.groupBy) {  // group by repo'
       if (type === 'repo')
-        return 'repo_id AS id, argMax(repo_name, time) AS name';
+        return `repo_id AS id, argMax(repo_name, ${config.groupTimeRange ? 'time' : 'created_at'}) AS name`;
       else
-        return `actor_id AS id, argMax(actor_login, time) AS name`;
+        return `actor_id AS id, argMax(actor_login, ${config.groupTimeRange ? 'time' : 'created_at'}) AS name`;
     } else if (config.groupBy === 'org') {
-      return `org_id AS id, argMax(org_login, time) AS name`;
+      return `org_id AS id, argMax(org_login, ${config.groupTimeRange ? 'time' : 'created_at'}) AS name`;
     } else {  // group by label
       return getLabelGroupConditionClauseForClickhouse(config);
     }

--- a/src/metrics/basic.ts
+++ b/src/metrics/basic.ts
@@ -239,9 +239,7 @@ export const getTimeRangeSumClauseForNeo4j = async (config: QueryConfig, type: s
 }
 
 export const getTimeRangeWhereClauseForClickhouse = (config: QueryConfig): string => {
-  const endDate = new Date(`${config.endYear}-${config.endMonth}-1`);
-  endDate.setMonth(config.endMonth);  // find next month
-  return ` created_at >= toDate('${config.startYear}-${config.startMonth}-1') AND created_at < toDate('${endDate.getFullYear()}-${endDate.getMonth() + 1}-1') `;
+  return ` created_at >= toDate('${config.startYear}-${config.startMonth}-1') AND created_at < dateAdd(month, 1, toDate('${config.endYear}-${config.endMonth}-1'))`;
 }
 
 // clickhouse label group condition


### PR DESCRIPTION
Signed-off-by: frank-zsy <syzhao1988@126.com>

Fix a bug when group time range is not set in query option.

Changes:

- Use `dateAdd(month, 1, toDate('${config.endYear}-${config.endMonth}-1')) AS time` if group time range is not set, because in some cases, we will use time to compare and aggregate data, so use the next month of end time will return correct result wile `1` is not right here.
- Use `created_at` rather than `time` to find out the latest names for actor and repo, because if group time range is not set, time is a constant so `argMax` will not work.