### PR TITLE
refactor: add reopened action to issues new metric

### DIFF
--- a/src/metrics/chaoss.ts
+++ b/src/metrics/chaoss.ts
@@ -145,7 +145,7 @@ ${getOutterOrderAndLimit(config, 'code_change_lines')}`;
 // Evolution - Issue Resolution
 export const chaossIssuesNew = async (config: QueryConfig) => {
   config = getMergedConfig(config);
-  const whereClauses: string[] = ["type = 'IssuesEvent' AND action = 'opened'"];
+  const whereClauses: string[] = ["type = 'IssuesEvent' AND action IN ('opened', 'reopened')"];
   const repoWhereClause = await getRepoWhereClauseForClickhouse(config);
   if (repoWhereClause) whereClauses.push(repoWhereClause);
   whereClauses.push(getTimeRangeWhereClauseForClickhouse(config));


### PR DESCRIPTION
Signed-off-by: frank-zsy <syzhao1988@126.com>

fix #1172 

Add `reopened` action to `issuesNew` metric.

With `reopened` action involved, the total number of issues looks good, minor difference due to log data loss.

<img width="603" alt="image" src="https://user-images.githubusercontent.com/8512426/216568316-88a4c99a-febb-4554-ab21-0509a3defef7.png">

<img width="567" alt="image" src="https://user-images.githubusercontent.com/8512426/216568361-c32445c6-8bcd-408c-857b-882a758003f8.png">
