### PR TITLE
fix: use meta.json instead of name.json as flag file

### DIFF
--- a/src/cron/tasks/monthly_export.ts
+++ b/src/cron/tasks/monthly_export.ts
@@ -104,11 +104,8 @@ const task: Task = {
         const name = row.name;
         if (!existsSync(join(exportBasePath, name))) {
           mkdirSync(join(exportBasePath, name), { recursive: true });
-          // this an empty flag file to indicate if the data is exported for this repo or user
-          try {
-            writeFileSync(join(exportBasePath, name + '.json'), '');
-          } catch { }
         }
+        writeFileSync(join(exportBasePath, name, 'meta.json'), JSON.stringify({ updatedAt: new Date().getTime() }));
         if (!Array.isArray(fields)) fields = [fields];
         const aggContent: any = {};
         for (let field of fields) {


### PR DESCRIPTION
Signed-off-by: frank-zsy <syzhao1988@126.com>

fix #1168 

Using `meta.json` as flag file instead of `owner/name.json` since the problem described in #1168 