### PR TITLE
feat: add activity developer details option

### DIFF
--- a/src/cron/tasks/monthly_export.ts
+++ b/src/cron/tasks/monthly_export.ts
@@ -190,7 +190,7 @@ const task: Task = {
       const { min, max } = repoPartitions[i];
       option.whereClause = `repo_id BETWEEN ${min} AND ${max} AND repo_id IN (SELECT id FROM ${exportRepoTableName})`;
       // [X-lab index] repo activity
-      await processMetric(getRepoActivity, option, getField('activity'));
+      await processMetric(getRepoActivity, { ...option, options: { developerDetail: true } }, [getField('activity'), getField('details', { targetKey: 'activity_details', ...arrayFieldOption })]);
       // [X-lab index] repo openrank
       await processMetric(getRepoOpenrank, option, getField('openrank'));
       // [X-lab index] repo attention

--- a/test/metrics.test.ts
+++ b/test/metrics.test.ts
@@ -43,7 +43,9 @@ describe('Index and metric test', () => {
   };
   describe('Indices tests', () => {
     it('activity', async () => {
-      await commonAssert(openDigger.getRepoActivity, 'activity');
+      await commonAssert(openDigger.getRepoActivity, 'activity', {
+        queryOptions: { options: { developerDetail: true } }
+      });
     });
   });
   describe('Metrics tests', () => {


### PR DESCRIPTION
Signed-off-by: frank-zsy <syzhao1988@126.com>

fix #1186 

Add a `developerDetail` option to activity index.

- With the option set to `true`, will return details about developer activity in every month.
- For monthly export task, add `activity_details.json` file to store the details of activity in every month.
- Add the option to unit test to make sure it won't break the function.