### PR TITLE
refactor: slice activity detail in case large size file

### DIFF
--- a/src/cron/tasks/monthly_export.ts
+++ b/src/cron/tasks/monthly_export.ts
@@ -190,7 +190,7 @@ const task: Task = {
       const { min, max } = repoPartitions[i];
       option.whereClause = `repo_id BETWEEN ${min} AND ${max} AND repo_id IN (SELECT id FROM ${exportRepoTableName})`;
       // [X-lab index] repo activity
-      await processMetric(getRepoActivity, { ...option, options: { developerDetail: true } }, [getField('activity'), getField('details', { targetKey: 'activity_details', ...arrayFieldOption })]);
+      await processMetric(getRepoActivity, { ...option, options: { developerDetail: true } }, [getField('activity'), getField('details', { targetKey: 'activity_details', ...arrayFieldOption, parser: arr => arr.length <= 100 ? arr : arr.filter(i => i[1] >= 2) })]);
       // [X-lab index] repo openrank
       await processMetric(getRepoOpenrank, option, getField('openrank'));
       // [X-lab index] repo attention


### PR DESCRIPTION
close #1186 

Slice activity detail array if the length is larger than 100 to avoid too large file like vscode.