### PR TITLE
Update Data: Update labeled data of Opensource DBMS with a github repo link based on dbdb.io and DB-Engines by Apr 13th, 2023.

### DIFF
--- a/labeled_data/technology/database/array.yml
+++ b/labeled_data/technology/database/array.yml
@@ -12,3 +12,4 @@ data:
     - 156942199 # repo:perone/euclidesdb
     - 40127179 # repo:pilosa/pilosa
     - 55072677 # repo:semi-technologies/weaviate
+    - 388946490 # repo:facebookincubator/velox

--- a/labeled_data/technology/database/document.yml
+++ b/labeled_data/technology/database/document.yml
@@ -101,3 +101,4 @@ data:
     - 125824259 # repo:xtdb/xtdb
     - 456549280 # repo:ydb-platform/ydb
     - 47479424 # repo:zerodb/zerodb
+    - 522606931 # repo:Anna-Team/AnnaDB

--- a/labeled_data/technology/database/key_value.yml
+++ b/labeled_data/technology/database/key_value.yml
@@ -167,3 +167,4 @@ data:
     - 9048279 # repo:yinqiwen/ardb
     - 105944401 # repo:yugabyte/yugabyte-db
     - 7357595 # repo:zopefoundation/ZODB
+    - 125234630 # repo:danielealbano/cachegrand

--- a/labeled_data/technology/database/multivalue.yml
+++ b/labeled_data/technology/database/multivalue.yml
@@ -6,3 +6,4 @@ data:
     - 5407611 # repo:dioptre/rasdaman
     - 1984888 # repo:gregjurman/openqm
     - 34215181 # repo:jrmarino/AdaBase
+    - 61269853 # repo:vanilladb/vanillacore

--- a/labeled_data/technology/database/relational.yml
+++ b/labeled_data/technology/database/relational.yml
@@ -153,3 +153,5 @@ data:
     - 105944401 # repo:yugabyte/yugabyte-db
     - 23452009 # repo:yxymit/DBx1000
     - 334353425 # repo:zettadb/kunlun
+    - 95817032 # repo:edgedb/edgedb
+    - 436658287 # repo:surrealdb/surrealdb

--- a/labeled_data/technology/database/wide_column.yml
+++ b/labeled_data/technology/database/wide_column.yml
@@ -21,3 +21,4 @@ data:
     - 28449431 # repo:scylladb/scylla
     - 28449431 # repo:scylladb/scylla
     - 41209174 # repo:strapdata/elassandra
+    - 388946490 # repo:facebookincubator/velox


### PR DESCRIPTION
Fix https://github.com/X-lab2017/open-digger/issues/1253

Batch label data: Incrementally add labels in April to the database technology repository.
Update Data: Update labeled data of Opensource DBMS with a github repo link based on dbdb.io and DB-Engines by Apr 13th, 2023. 

**Filter conditions**: 
- Collected by dbdb.io on Apr 13th, 2023 OR Rankings in the DB-Engines Rankings table on Apr 13th, 2023; 
- Has open source license; 
- Has repository link on GitHub; 
- The increment relative to the version https://github.com/X-lab2017/open-digger/issues/1245 on Mar 31st, 2023.