### PR TITLE
fix: change China to CN and remove 2 missing repos

### DIFF
--- a/labeled_data/technology/database/document.yml
+++ b/labeled_data/technology/database/document.yml
@@ -53,7 +53,6 @@ data:
     - 58524063 # repo:jclo/picodb
     - 4859 # repo:jcrosby/cloudkit
     - 652189 # repo:jedisct1/Pincaster
-    - jsqldb/jsqldb # not found
     - 1776883 # repo:kimchy/compass
     - 376679845 # repo:losfair/RefineDB
     - 9795883 # repo:louischatriot/nedb

--- a/labeled_data/technology/database/key_value.yml
+++ b/labeled_data/technology/database/key_value.yml
@@ -46,7 +46,6 @@ data:
     - 791522 # repo:basho/riak_kv
     - 88422672 # repo:bergdb/bergdb
     - 2380364 # repo:berkeleydb/libdb
-    - beryldb/beryldb # not found
     - 51290852 # repo:bigchaindb/bigchaindb
     - 57401138 # repo:bitnine-oss/agensgraph
     - 320459354 # repo:bytedance/terarkdb

--- a/src/cron/tasks/monthly_export.ts
+++ b/src/cron/tasks/monthly_export.ts
@@ -75,7 +75,7 @@ const task: Task = {
     }
 
     // start to export data for all repos and actors
-    // split the sql into 20 pieces to avoid memory issue
+    // split the sql into 40 pieces to avoid memory issue
     const getPartition = async (type: 'User' | 'Repo'): Promise<Array<{ min: number, max: number }>> => {
       const quantileArr: number[] = [];
       for (let i = 0.025; i <= 0.975; i += 0.025) {

--- a/src/cron/tasks/open_leaderboard.ts
+++ b/src/cron/tasks/open_leaderboard.ts
@@ -32,7 +32,7 @@ const task: Task = {
 
     // get chinese month actor activity
     const chineseUserMonthActivityData = await getUserActivity({
-      labelUnion: [':regions/China'],
+      labelUnion: [':regions/CN'],
       startYear, startMonth, endYear, endMonth,
       order: 'DESC', limit: -1, precision: 2,
       groupTimeRange: 'month', limitOption: 'each',
@@ -56,7 +56,7 @@ const task: Task = {
 
     // get chinese actor year acitivity
     const chineseUserYearActivityData = await getUserActivity({
-      labelUnion: [':regions/China'],
+      labelUnion: [':regions/CN'],
       startYear, startMonth, endYear, endMonth,
       order: 'DESC', limit: -1, precision: 2,
       groupTimeRange: 'year', limitOption: 'each',
@@ -128,7 +128,7 @@ const task: Task = {
     // get chinese company activity
     // by month
     const chineseCompanyMonthActivityData = await getRepoActivity({
-      labelIntersect: ['Company', ':regions/China'],
+      labelIntersect: ['Company', ':regions/CN'],
       startYear, startMonth, endYear, endMonth,
       order: 'DESC', limit: -1, precision: 2,
       groupBy: 'Company', limitOption: 'each',
@@ -152,7 +152,7 @@ const task: Task = {
 
     // by year
     const chineseCompanyYearActivityData = await getRepoActivity({
-      labelIntersect: ['Company', ':regions/China'],
+      labelIntersect: ['Company', ':regions/CN'],
       startYear, startMonth, endYear, endMonth,
       order: 'DESC', limit: -1, precision: 2,
       groupBy: 'Company', limitOption: 'each',
@@ -273,7 +273,7 @@ const task: Task = {
     // get Chinese repo activity
     // by month
     const chineseRepoMonthActivityData = await getRepoActivity({
-      labelUnion: [':regions/China'],
+      labelUnion: [':regions/CN'],
       startYear, startMonth, endYear, endMonth,
       order: 'DESC', limit: -1, precision: 2,
       groupTimeRange: 'month', limitOption: 'each',
@@ -295,7 +295,7 @@ const task: Task = {
     writeData(chineseRepoMonthActivityMap, 'Repo_China_Month', 'activity/repo/chinese');
     // by year
     const chineseRepoYearActivityData = await getRepoActivity({
-      labelUnion: [':regions/China'],
+      labelUnion: [':regions/CN'],
       startYear, startMonth, endYear, endMonth,
       order: 'DESC', limit: -1, precision: 2,
       groupTimeRange: 'year', limitOption: 'each',
@@ -320,7 +320,7 @@ const task: Task = {
     // get Chinese actor OpenRank
     // by month
     const chineseUserMonthOpenrankData = await getUserOpenrank({
-      labelUnion: [':regions/China'],
+      labelUnion: [':regions/CN'],
       startYear, startMonth, endYear, endMonth,
       order: 'DESC', limit: -1, precision: 2,
       groupTimeRange: 'month', limitOption: 'each',
@@ -333,7 +333,7 @@ const task: Task = {
     writeData(chineseUserMonthOpenrankMap, 'Actor_China_Month', 'open_rank/actor/chinese');
     // by year
     const chineseUserYearOpenrankData = await getUserOpenrank({
-      labelUnion: [':regions/China'],
+      labelUnion: [':regions/CN'],
       startYear, startMonth, endYear, endMonth,
       order: 'DESC', limit: -1, precision: 2,
       groupTimeRange: 'year', limitOption: 'each',
@@ -376,7 +376,7 @@ const task: Task = {
     // get Chinese repo OpenRank
     // by month
     const chineseRepoMonthOpenrankData = await getRepoOpenrank({
-      labelUnion: [':regions/China'],
+      labelUnion: [':regions/CN'],
       startYear, startMonth, endYear, endMonth,
       order: 'DESC', limit, precision: 2,
       groupTimeRange: 'month', limitOption: 'each',
@@ -389,7 +389,7 @@ const task: Task = {
     writeData(chineseRepoMonthOpenrankMap, 'Repo_China_Month', 'open_rank/repo/chinese');
     // by year
     const chineseRepoYearOpenrankData = await getRepoOpenrank({
-      labelUnion: [':regions/China'],
+      labelUnion: [':regions/CN'],
       startYear, startMonth, endYear, endMonth,
       order: 'DESC', limit: -1, precision: 2,
       groupTimeRange: 'year', limitOption: 'each',
@@ -405,7 +405,7 @@ const task: Task = {
     // get Chinese company
     // by month
     const chineseCompanyRepoMonthOpenrankData = await getRepoOpenrank({
-      labelIntersect: [':regions/China', 'Company'],
+      labelIntersect: [':regions/CN', 'Company'],
       startYear, startMonth, endYear, endMonth,
       order: 'DESC', limit, precision: 2, limitOption: 'each',
       groupTimeRange: 'month', groupBy: 'Company',
@@ -418,7 +418,7 @@ const task: Task = {
     writeData(chineseCompanyRepoMonthOpenrankMap, 'Company_China_Month', 'open_rank/company/chinese');
     // by year
     const chineseCompanyRepoYearOpenrankData = await getRepoOpenrank({
-      labelIntersect: [':regions/China', 'Company'],
+      labelIntersect: [':regions/CN', 'Company'],
       startYear, startMonth, endYear, endMonth,
       order: 'DESC', limit: -1, precision: 2, limitOption: 'each',
       groupTimeRange: 'year', groupBy: 'Company',


### PR DESCRIPTION
As #1267 merged, label `:regions/China` changes to `:regions/CN`, so we need to change the label in monthly export task, as well as two missing repos in database label data.