### PR TITLE
Update Data: Update labeled data of Opensource DBMS with a github repo link based on dbdb.io and DB-Engines by May 7th, 2023. 

### DIFF
--- a/labeled_data/technology/database/array.yml
+++ b/labeled_data/technology/database/array.yml
@@ -3,7 +3,9 @@ type: Tech-1
 data:
   github_repo:
     - 86868560 # repo:TileDB-Inc/TileDB
+    - 17699493 # repo:cran/scidb
     - 96580430 # repo:datajaguar/jaguardb
+    - 388946490 # repo:facebookincubator/velox
     - 304530333 # repo:featureform/embeddinghub
     - 45732002 # repo:jnidzwetzki/bboxdb
     - 208728772 # repo:milvus-io/milvus
@@ -12,4 +14,3 @@ data:
     - 156942199 # repo:perone/euclidesdb
     - 40127179 # repo:pilosa/pilosa
     - 55072677 # repo:semi-technologies/weaviate
-    - 388946490 # repo:facebookincubator/velox

--- a/labeled_data/technology/database/document.yml
+++ b/labeled_data/technology/database/document.yml
@@ -5,6 +5,7 @@ data:
     - 215532341 # repo:256dpi/lungo
     - 25780780 # repo:AlaSQL/alasql
     - 61179047 # repo:Alachisoft/NosDB
+    - 522606931 # repo:Anna-Team/AnnaDB
     - 396867188 # repo:ArcadeData/arcadedb
     - 1374129 # repo:BaseXdb/basex
     - 8799170 # repo:DevrexLabs/OrigoDB
@@ -28,6 +29,7 @@ data:
     - 2649214 # repo:arangodb/arangodb
     - 36778364 # repo:attic-labs/noms
     - 141378316 # repo:beardedeagle/mnesiac
+    - 88422672 # repo:bergdb/bergdb
     - 2380364 # repo:berkeleydb/libdb
     - 51290852 # repo:bigchaindb/bigchaindb
     - 57401138 # repo:bitnine-oss/agensgraph
@@ -83,6 +85,7 @@ data:
     - 6452529 # repo:rethinkdb/rethinkdb
     - 336867666 # repo:ribelo/doxa
     - 34056205 # repo:sachin-sinha/BangDB
+    - 5841618 # repo:sedna/sedna
     - 9525219 # repo:sergeyksv/tingodb
     - 4604367 # repo:sirixdb/sirix
     - 295745510 # repo:small-tech/jsdb
@@ -97,7 +100,7 @@ data:
     - 18351848 # repo:typicode/lowdb
     - 25364889 # repo:unnamed38/fueldb
     - 60377070 # repo:vespa-engine/vespa
+    - 735981 # repo:xapian/xapian
     - 125824259 # repo:xtdb/xtdb
     - 456549280 # repo:ydb-platform/ydb
     - 47479424 # repo:zerodb/zerodb
-    - 522606931 # repo:Anna-Team/AnnaDB

--- a/labeled_data/technology/database/graph.yml
+++ b/labeled_data/technology/database/graph.yml
@@ -44,4 +44,3 @@ data:
     - 605999 # repo:twitter-archive/flockdb
     - 63110867 # repo:vaticle/typedb
     - 146459443 # repo:vesoft-inc/nebula
-    - 146459443 # repo:vesoft-inc/nebula

--- a/labeled_data/technology/database/key_value.yml
+++ b/labeled_data/technology/database/key_value.yml
@@ -48,6 +48,7 @@ data:
     - 2380364 # repo:berkeleydb/libdb
     - 51290852 # repo:bigchaindb/bigchaindb
     - 57401138 # repo:bitnine-oss/agensgraph
+    - 15345331 # repo:boltdb/bolt
     - 320459354 # repo:bytedance/terarkdb
     - 33275300 # repo:cachelot/cachelot
     - 1196286 # repo:cbd/edis
@@ -57,18 +58,16 @@ data:
     - 66783145 # repo:couchbase/couchbase-lite-core
     - 12497058 # repo:couchbase/forestdb
     - 811881 # repo:cruppstahl/upscaledb
-    - 96580430 # repo:datajaguar/jaguardb
+    - 125234630 # repo:danielealbano/cachegrand
     - 96580430 # repo:datajaguar/jaguardb
     - 292903178 # repo:deroproject/graviton
     - 132499340 # repo:developit/histore
-    - 80087836 # repo:dgraph-io/badger
     - 80087836 # repo:dgraph-io/badger
     - 3115025 # repo:dlitz/resin
     - 437245741 # repo:dragonflydb/dragonfly
     - 17224514 # repo:ehcache/ehcache3
     - 393005910 # repo:engula/engula
     - 278320002 # repo:estraier/tkrzw
-    - 94593596 # repo:etcd-io/bbolt
     - 94593596 # repo:etcd-io/bbolt
     - 11225014 # repo:etcd-io/etcd
     - 6934395 # repo:facebook/rocksdb
@@ -111,6 +110,7 @@ data:
     - 4211523 # repo:oleiade/Elevator
     - 12106192 # repo:oleiade/trousseau
     - 242776849 # repo:oracle/coherence
+    - 192418550 # repo:oracle/nosql-go-sdk
     - 48617634 # repo:orbitdb/orbit-db
     - 7083240 # repo:orientechnologies/orientdb
     - 278684767 # repo:petermattis/pebble
@@ -166,4 +166,3 @@ data:
     - 9048279 # repo:yinqiwen/ardb
     - 105944401 # repo:yugabyte/yugabyte-db
     - 7357595 # repo:zopefoundation/ZODB
-    - 125234630 # repo:danielealbano/cachegrand

--- a/labeled_data/technology/database/object_oriented.yml
+++ b/labeled_data/technology/database/object_oriented.yml
@@ -30,6 +30,7 @@ data:
     - 7083240 # repo:orientechnologies/orientdb
     - 37285717 # repo:pilgr/Paper
     - 14702444 # repo:pipelinedb/pipelinedb
+    - 927442 # repo:postgres/postgres
     - 1917262 # repo:realm/realm-core
     - 3893984 # repo:tzaeschke/zoodb
     - 88111990 # repo:zhihu/Matisse

--- a/labeled_data/technology/database/relational.yml
+++ b/labeled_data/technology/database/relational.yml
@@ -76,6 +76,7 @@ data:
     - 8544988 # repo:dreamdbvilas/wonderdb
     - 97518356 # repo:dremio/dremio-oss
     - 138754790 # repo:duckdb/duckdb
+    - 95817032 # repo:edgedb/edgedb
     - 341208515 # repo:edgelesssys/edgelessdb
     - 61373806 # repo:elasql/elasql
     - 387622288 # repo:elliotchance/vsql
@@ -85,11 +86,11 @@ data:
     - 392839612 # repo:firebolt-db/firebolt-python-sdk
     - 305513242 # repo:fluree/db
     - 600860 # repo:fosslc/Ingres
+    - 148087762 # repo:georgia-tech-db/eva
     - 3084708 # repo:ggaughan/ThinkSQL
     - 24650236 # repo:google/lovefield
     - 44781140 # repo:greenplum-db/gpdb
     - 33745913 # repo:h2database/h2database
-    - 90541149 # repo:heavyai/heavydb
     - 90541149 # repo:heavyai/heavydb
     - 291675222 # repo:hstreamdb/hstream
     - 87414843 # repo:hyrise/hyrise
@@ -122,7 +123,6 @@ data:
     - 927442 # repo:postgres/postgres
     - 258454329 # repo:ppml38/icecoal
     - 5349565 # repo:prestodb/presto
-    - 5349565 # repo:prestodb/presto
     - 275838748 # repo:qikkDB/qikkdb
     - 19257422 # repo:questdb/questdb
     - 5665061 # repo:radare/sdb
@@ -139,6 +139,7 @@ data:
     - 176278485 # repo:sqlite/sqlite
     - 151367139 # repo:stellarsql/StellarSQL
     - 12067343 # repo:stephentu/silo
+    - 436658287 # repo:surrealdb/surrealdb
     - 196353673 # repo:taosdata/TDengine
     - 285012797 # repo:tensorbase/tensorbase
     - 443220240 # repo:tinyplex/tinybase
@@ -153,5 +154,3 @@ data:
     - 105944401 # repo:yugabyte/yugabyte-db
     - 23452009 # repo:yxymit/DBx1000
     - 334353425 # repo:zettadb/kunlun
-    - 95817032 # repo:edgedb/edgedb
-    - 436658287 # repo:surrealdb/surrealdb

--- a/labeled_data/technology/database/time_series.yml
+++ b/labeled_data/technology/database/time_series.yml
@@ -10,6 +10,7 @@ data:
     - 55093657 # repo:SiriDB/siridb-server
     - 150954997 # repo:VictoriaMetrics/VictoriaMetrics
     - 158975124 # repo:apache/iotdb
+    - 420965027 # repo:cnosdb/cnosdb
     - 4254338 # repo:graphite-project/graphite-web
     - 52420005 # repo:griddb/griddb
     - 17705626 # repo:hawkular/hawkular-metrics

--- a/labeled_data/technology/database/wide_column.yml
+++ b/labeled_data/technology/database/wide_column.yml
@@ -13,12 +13,11 @@ data:
     - 18129915 # repo:baidu/tera
     - 182849188 # repo:delta-io/delta
     - 191676087 # repo:eleme/lindb
+    - 388946490 # repo:facebookincubator/velox
     - 1584552 # repo:hypertable/hypertable
     - 13124802 # repo:influxdata/influxdb
     - 191442206 # repo:kashirin-alex/swc-db
     - 473235285 # repo:polarsignals/frostdb
     - 5349565 # repo:prestodb/presto
     - 28449431 # repo:scylladb/scylla
-    - 28449431 # repo:scylladb/scylla
     - 41209174 # repo:strapdata/elassandra
-    - 388946490 # repo:facebookincubator/velox


### PR DESCRIPTION
Fix https://github.com/X-lab2017/open-digger/issues/1283

Batch label data: Incrementally add labels in 202305 to the database technology repository.


Filter conditions:

- Collected by dbdb.io on May 7th, 2023 OR Rankings in the DB-Engines Rankings table on May 7th, 2023;
- Has open source license;
- Has repository link on GitHub;

- The increment relative to the version https://github.com/X-lab2017/open-digger/issues/1253 on Apr 13th, 2023.