### PR TITLE
Update Data: Update labeled data of Opensource DBMS with a github repo link based on dbdb.io and DB-Engines by July 24th, 2023.

### DIFF
--- a/labeled_data/technology/database/array.yml
+++ b/labeled_data/technology/database/array.yml
@@ -6,8 +6,10 @@ data:
     - 86868560 # repo:TileDB-Inc/TileDB
     - 17699493 # repo:cran/scidb
     - 96580430 # repo:datajaguar/jaguardb
+    - 5407611 # repo:dioptre/rasdaman
     - 304530333 # repo:featureform/embeddinghub
     - 45732002 # repo:jnidzwetzki/bboxdb
+    - 520096046 # repo:marqo-ai/marqo
     - 208728772 # repo:milvus-io/milvus
     - 478288303 # repo:nuclia/nucliadb
     - 162765004 # repo:peermaps/eyros

--- a/labeled_data/technology/database/document.yml
+++ b/labeled_data/technology/database/document.yml
@@ -35,6 +35,7 @@ data:
     - 57401138 # repo:bitnine-oss/agensgraph
     - 127338417 # repo:bluzi/jsonstore
     - 234091935 # repo:c9fe/sirdb
+    - 546206616 # repo:chroma-core/chroma
     - 13353426 # repo:cinchapi/concourse
     - 66783145 # repo:couchbase/couchbase-lite-core
     - 9342529 # repo:crate/crate
@@ -56,6 +57,7 @@ data:
     - 4859 # repo:jcrosby/cloudkit
     - 652189 # repo:jedisct1/Pincaster
     - 1776883 # repo:kimchy/compass
+    - 607441698 # repo:lancedb/lancedb
     - 376679845 # repo:losfair/RefineDB
     - 9795883 # repo:louischatriot/nedb
     - 23315232 # repo:mbdavid/LiteDB

--- a/labeled_data/technology/database/graph.yml
+++ b/labeled_data/technology/database/graph.yml
@@ -9,6 +9,7 @@ data:
     - 45098765 # repo:PureSolTechnologies/DuctileDB
     - 84458512 # repo:RedisGraph/RedisGraph
     - 22475123 # repo:amark/gun
+    - 276293034 # repo:apache/age
     - 2282376 # repo:apache/giraph
     - 141376301 # repo:apache/incubator-hugegraph
     - 30449481 # repo:apache/tinkerpop

--- a/labeled_data/technology/database/key_value.yml
+++ b/labeled_data/technology/database/key_value.yml
@@ -72,6 +72,7 @@ data:
     - 11225014 # repo:etcd-io/etcd
     - 6934395 # repo:facebook/rocksdb
     - 70541093 # repo:facebookarchive/beringei
+    - 606800919 # repo:firstbatchxyz/hollowdb
     - 292049131 # repo:genderev/assassin
     - 67936193 # repo:gfredericks/quinedb
     - 23405758 # repo:google/leveldb

--- a/labeled_data/technology/database/object_oriented.yml
+++ b/labeled_data/technology/database/object_oriented.yml
@@ -28,6 +28,7 @@ data:
     - 351806852 # repo:neondatabase/neon
     - 79901405 # repo:objectbox/objectbox-java
     - 7083240 # repo:orientechnologies/orientdb
+    - 432844875 # repo:orioledb/orioledb
     - 37285717 # repo:pilgr/Paper
     - 14702444 # repo:pipelinedb/pipelinedb
     - 927442 # repo:postgres/postgres

--- a/labeled_data/technology/database/relational.yml
+++ b/labeled_data/technology/database/relational.yml
@@ -8,6 +8,7 @@ data:
     - 623337117 # repo:ALTIBASE/altibase
     - 25780780 # repo:AlaSQL/alasql
     - 22427082 # repo:BTrDB/btrdb-server
+    - 581145740 # repo:ByConity/ByConity
     - 52080367 # repo:CUBRID/cubrid
     - 496505424 # repo:CeresDB/ceresdb
     - 60246359 # repo:ClickHouse/ClickHouse
@@ -104,8 +105,10 @@ data:
     - 371172777 # repo:kelindar/column
     - 199466858 # repo:kkuchta/tabdb
     - 7502247 # repo:lealone/Lealone
+    - 509396909 # repo:lingo-db/lingo-db
     - 23013460 # repo:lsst/qserv
     - 61153677 # repo:m3db/m3
+    - 564689243 # repo:man-group/ArcticDB
     - 95614931 # repo:manticoresoftware/manticoresearch
     - 429630067 # repo:marsupialtail/quokka
     - 339993112 # repo:matrixorigin/matrixone
@@ -117,6 +120,7 @@ data:
     - 372536760 # repo:oceanbase/oceanbase
     - 507829396 # repo:openGemini/openGemini
     - 276117477 # repo:opengauss-mirror/openGauss-server
+    - 432844875 # repo:orioledb/orioledb
     - 3766330 # repo:pentaho/mondrian
     - 30753733 # repo:percona/percona-server
     - 9509125 # repo:percona/tokudb-engine


### PR DESCRIPTION
Fix https://github.com/X-lab2017/open-digger/issues/1351

Batch label data: Incrementally add labels in 202307 to the database technology repository.

Filter conditions:
- Collected by dbdb.io on July 24th, 2023 OR Rankings in the DB-Engines Rankings table on July 24th, 2023;
- Has open source license;
- Has repository link on GitHub;
- The increment relative to the version #1313 on June 10th, 2023.

Features:
- Add new repositories with labels in [Array, Document, Graph, Key-value, Object oriented, Relational].