### PR TITLE
Update Data: Update labeled data of Opensource DBMS with a github repo link based on dbdb.io and DB-Engines by Aug 26, 2023.

### DIFF
--- a/labeled_data/technology/database/document.yml
+++ b/labeled_data/technology/database/document.yml
@@ -93,6 +93,7 @@ data:
     - 295745510 # repo:small-tech/jsdb
     - 436658287 # repo:surrealdb/surrealdb
     - 22761491 # repo:symisc/unqlite
+    - 911980 # repo:tarantool/tarantool
     - 3920536 # repo:teamdev/densodb
     - 11654790 # repo:techfort/LokiJS
     - 198466472 # repo:terminusdb/terminusdb

--- a/labeled_data/technology/database/graph.yml
+++ b/labeled_data/technology/database/graph.yml
@@ -21,6 +21,7 @@ data:
     - 41946572 # repo:degdb/degdb
     - 41349039 # repo:dgraph-io/dgraph
     - 402209532 # repo:dyedgreen/cqlite
+    - 668673665 # repo:falkordb/falkordb
     - 305513242 # repo:fluree/db
     - 47973088 # repo:gchq/Gaffer
     - 38727503 # repo:hypergraphdb/hypergraphdb

--- a/labeled_data/technology/database/relational.yml
+++ b/labeled_data/technology/database/relational.yml
@@ -105,6 +105,7 @@ data:
     - 371172777 # repo:kelindar/column
     - 199466858 # repo:kkuchta/tabdb
     - 7502247 # repo:lealone/Lealone
+    - 543276238 # repo:libsql/libsql
     - 509396909 # repo:lingo-db/lingo-db
     - 23013460 # repo:lsst/qserv
     - 61153677 # repo:m3db/m3


### PR DESCRIPTION
Fix https://github.com/X-lab2017/open-digger/issues/1376

Batch label data: Incrementally add labels in 202308 to the database technology repository.

Filter conditions:

- Collected by dbdb.io on Aug 26, 2023 OR Rankings in the DB-Engines Rankings table on Aug 26, 2023;
- Has open source license;
- Has repository link on GitHub;
- The increment relative to the version https://github.com/X-lab2017/open-digger/issues/1351 on July 24th, 2023.

Features:

- Add new repositories with labels in [Document, Graph, Relational].