### PR TITLE
Update Data: Update labeled data of Opensource DBMS with a github repo link based on dbdb.io and DB-Engines by Sep 26, 2023. 

### DIFF
--- a/labeled_data/technology/database/array.yml
+++ b/labeled_data/technology/database/array.yml
@@ -7,12 +7,7 @@ data:
     - 17699493 # repo:cran/scidb
     - 96580430 # repo:datajaguar/jaguardb
     - 5407611 # repo:dioptre/rasdaman
-    - 304530333 # repo:featureform/embeddinghub
+    - 664133375 # repo:epsilla-cloud/vectordb
     - 45732002 # repo:jnidzwetzki/bboxdb
-    - 520096046 # repo:marqo-ai/marqo
-    - 208728772 # repo:milvus-io/milvus
-    - 478288303 # repo:nuclia/nucliadb
     - 162765004 # repo:peermaps/eyros
     - 156942199 # repo:perone/euclidesdb
-    - 40127179 # repo:pilosa/pilosa
-    - 55072677 # repo:semi-technologies/weaviate

--- a/labeled_data/technology/database/document.yml
+++ b/labeled_data/technology/database/document.yml
@@ -28,6 +28,7 @@ data:
     - 137869753 # repo:appy-one/acebase
     - 2649214 # repo:arangodb/arangodb
     - 36778364 # repo:attic-labs/noms
+    - 642912355 # repo:awa-ai/awadb
     - 141378316 # repo:beardedeagle/mnesiac
     - 88422672 # repo:bergdb/bergdb
     - 2380364 # repo:berkeleydb/libdb
@@ -46,6 +47,7 @@ data:
     - 11695619 # repo:eXist-db/exist
     - 266444815 # repo:earthstar-project/earthstar
     - 507775 # repo:elastic/elasticsearch
+    - 587246478 # repo:endatabas/endb
     - 14143348 # repo:fakemongo/fongo
     - 305513242 # repo:fluree/db
     - 138411034 # repo:genjidb/genji
@@ -55,11 +57,15 @@ data:
     - 4984118 # repo:ioquatix/relaxo
     - 58524063 # repo:jclo/picodb
     - 4859 # repo:jcrosby/cloudkit
+    - 628503457 # repo:jdagdelen/hyperDB
     - 652189 # repo:jedisct1/Pincaster
+    - 635374751 # repo:jina-ai/vectordb
+    - 632269609 # repo:kagisearch/vectordb
     - 1776883 # repo:kimchy/compass
     - 607441698 # repo:lancedb/lancedb
     - 376679845 # repo:losfair/RefineDB
     - 9795883 # repo:louischatriot/nedb
+    - 520096046 # repo:marqo-ai/marqo
     - 23315232 # repo:mbdavid/LiteDB
     - 130688011 # repo:meilisearch/meilisearch
     - 26573806 # repo:mgholam/RaptorDB-Document
@@ -84,6 +90,7 @@ data:
     - 129436009 # repo:rakibtg/SleekDB
     - 542714 # repo:ravendb/ravendb
     - 1917262 # repo:realm/realm-core
+    - 223462217 # repo:resilientdb/resilientdb
     - 6452529 # repo:rethinkdb/rethinkdb
     - 336867666 # repo:ribelo/doxa
     - 34056205 # repo:sachin-sinha/BangDB
@@ -102,6 +109,8 @@ data:
     - 184711 # repo:typicaljoe/taffydb
     - 18351848 # repo:typicode/lowdb
     - 25364889 # repo:unnamed38/fueldb
+    - 186332888 # repo:vearch/vearch
+    - 634656527 # repo:vector5ai/vector5db
     - 60377070 # repo:vespa-engine/vespa
     - 735981 # repo:xapian/xapian
     - 125824259 # repo:xtdb/xtdb

--- a/labeled_data/technology/database/object_oriented.yml
+++ b/labeled_data/technology/database/object_oriented.yml
@@ -2,7 +2,6 @@ name: Database - Object Oriented
 type: Tech-1
 data:
   github_repo:
-    - 107504377 # repo:ADBSQL/AntDB
     - 681142 # repo:Bobris/BTDB
     - 52080367 # repo:CUBRID/cubrid
     - 329729926 # repo:CondensationDB/Condensation-java

--- a/labeled_data/technology/database/relational.yml
+++ b/labeled_data/technology/database/relational.yml
@@ -83,6 +83,8 @@ data:
     - 341208515 # repo:edgelesssys/edgelessdb
     - 61373806 # repo:elasql/elasql
     - 387622288 # repo:elliotchance/vsql
+    - 587246478 # repo:endatabas/endb
+    - 183929744 # repo:erikgrinaker/toydb
     - 59475316 # repo:eventql/eventql
     - 388946490 # repo:facebookincubator/velox
     - 40127179 # repo:featurebasedb/featurebase
@@ -132,6 +134,7 @@ data:
     - 927442 # repo:postgres/postgres
     - 258454329 # repo:ppml38/icecoal
     - 5349565 # repo:prestodb/presto
+    - 26774602 # repo:proullon/ramsql
     - 275838748 # repo:qikkDB/qikkdb
     - 19257422 # repo:questdb/questdb
     - 5665061 # repo:radare/sdb

--- a/labeled_data/technology/database/vector.yml
+++ b/labeled_data/technology/database/vector.yml
@@ -3,8 +3,19 @@ type: Tech-1
 data:
   github_repo:
     - 201403923 # repo:activeloopai/deeplake
+    - 642912355 # repo:awa-ai/awadb
     - 546206616 # repo:chroma-core/chroma
+    - 304530333 # repo:featureform/embeddinghub
+    - 628503457 # repo:jdagdelen/hyperDB
+    - 635374751 # repo:jina-ai/vectordb
+    - 632269609 # repo:kagisearch/vectordb
+    - 242383787 # repo:marekgalovic/anndb
+    - 520096046 # repo:marqo-ai/marqo
     - 208728772 # repo:milvus-io/milvus
+    - 478288303 # repo:nuclia/nucliadb
+    - 40127179 # repo:pilosa/pilosa
     - 268163609 # repo:qdrant/qdrant
     - 55072677 # repo:semi-technologies/weaviate
     - 195619075 # repo:vdaas/vald
+    - 186332888 # repo:vearch/vearch
+    - 634656527 # repo:vector5ai/vector5db


### PR DESCRIPTION
Fix https://github.com/X-lab2017/open-digger/issues/1393

Batch label data: Incrementally add labels in 202309 to the database technology repository.

Filter conditions:

- Collected by dbdb.io on Sep 26, 2023 OR Rankings in the DB-Engines Rankings table on Sep 26, 2023;
- Has open source license;
- Has repository link on GitHub;
- The increment relative to the version https://github.com/X-lab2017/open-digger/issues/1376 on Aug 26, 2023.

Features:

- Add new repositories with labels in [Array, Document, Object Oriented, Relational, Vector].

Notes: 

- Last month, [dbdb.io](https://dbdb.io/) divided the label “Array / Matrix / Vector” into the label “Array / Matrix” and the label “Vector”.
