### PR TITLE
feat: export quarter and year data to OSS in monthly export

### DIFF
--- a/src/metrics/basic.ts
+++ b/src/metrics/basic.ts
@@ -66,6 +66,35 @@ export const forEveryMonth = async (startYear: number, startMonth: number, endYe
   }
 }
 
+export const forEveryQuarterByConfig = async (config: QueryConfig, func: (y: number, q: number) => Promise<any>) => {
+  const quarters: { y: number, q: number }[] = [];
+  let lastQuarter = -1;
+  await forEveryMonthByConfig(config, async (y, m) => {
+    const q = Math.ceil(m / 3);
+    if (q !== lastQuarter) {
+      quarters.push({ y, q });
+      lastQuarter = q;
+    }
+  });
+  for (const i of quarters) {
+    await func(i.y, i.q);
+  }
+}
+
+export const forEveryYearByConfig = async (config: QueryConfig, func: (y: number) => Promise<any>) => {
+  const years: number[] = [];
+  let lastYear = -1;
+  await forEveryMonthByConfig(config, async y => {
+    if (y !== lastYear) {
+      years.push(y);
+      lastYear = y;
+    }
+  });
+  for (const y of years) {
+    await func(y);
+  }
+}
+
 // Repo
 export const getRepoWhereClauseForNeo4j = (config: QueryConfig): string | null => {
   const repoWhereClauseArray: string[] = [];

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1,0 +1,32 @@
+import assert from 'assert';
+import { forEveryMonthByConfig, forEveryQuarterByConfig, forEveryYearByConfig } from '../src/metrics/basic';
+
+describe('Basic functions test', () => {
+  describe('Time range functions', () => {
+    const queryConfig: any = { startYear: 2021, startMonth: 3, endYear: 2023, endMonth: 10 };
+
+    it('Should return correct year and month for forEveryMonthByConfig', async () => {
+      const monthes: string[] = [];
+      await forEveryMonthByConfig(queryConfig, async (y, m) => {
+        monthes.push(`${y}-${m}`);
+      });
+      assert(JSON.stringify(monthes) === '["2021-3","2021-4","2021-5","2021-6","2021-7","2021-8","2021-9","2021-10","2021-11","2021-12","2022-1","2022-2","2022-3","2022-4","2022-5","2022-6","2022-7","2022-8","2022-9","2022-10","2022-11","2022-12","2023-1","2023-2","2023-3","2023-4","2023-5","2023-6","2023-7","2023-8","2023-9","2023-10"]');
+    });
+
+    it('Should return correct year and month for forEveryQuarterByConfig', async () => {
+      const quarters: string[] = [];
+      await forEveryQuarterByConfig(queryConfig, async (y, q) => {
+        quarters.push(`${y}Q${q}`);
+      });
+      assert(JSON.stringify(quarters) === '["2021Q1","2021Q2","2021Q3","2021Q4","2022Q1","2022Q2","2022Q3","2022Q4","2023Q1","2023Q2","2023Q3","2023Q4"]');
+    });
+
+    it('Should return correct year and month for forEveryYearByConfig', async () => {
+      const years: string[] = [];
+      await forEveryYearByConfig(queryConfig, async y => {
+        years.push(`${y}`);
+      });
+      assert(JSON.stringify(years) === '["2021","2022","2023"]');
+    });
+  });
+});


### PR DESCRIPTION
close #1105 
close #1388 

- Export quarter and year data to OSS in monthly export task.
- The new keys will be directly added into the data.
- Add basic functions `forEveryQuarterbyConfig` and `forEveryYearByConfig` as well as their unit tests.