### PR TITLE
Update data for Database technical area labled on dbdb.io and DB-Engines Ranking by Nov 29, 2023.

### DIFF
--- a/labeled_data/technology/database/document.yml
+++ b/labeled_data/technology/database/document.yml
@@ -10,6 +10,7 @@ data:
     - 1374129 # repo:BaseXdb/basex
     - 8799170 # repo:DevrexLabs/OrigoDB
     - 422821402 # repo:FerretDB/FerretDB
+    - 605189726 # repo:FgForrest/evitaDB
     - 8313554 # repo:Greg0/Lazer-Database
     - 10296238 # repo:HouzuoGuo/tiedot
     - 19271154 # repo:JetBrains/xodus
@@ -82,6 +83,7 @@ data:
     - 192418550 # repo:oracle/nosql-go-sdk
     - 48617634 # repo:orbitdb/orbit-db
     - 7083240 # repo:orientechnologies/orientdb
+    - 453191009 # repo:ostafen/clover
     - 2662146 # repo:patx/pickledb
     - 39519916 # repo:percona/percona-server-mongodb
     - 166387176 # repo:polypheny/Polypheny-DB
@@ -97,6 +99,7 @@ data:
     - 6452529 # repo:rethinkdb/rethinkdb
     - 336867666 # repo:ribelo/doxa
     - 34056205 # repo:sachin-sinha/BangDB
+    - 664816265 # repo:scratchdata/ScratchDB
     - 5841618 # repo:sedna/sedna
     - 9525219 # repo:sergeyksv/tingodb
     - 4604367 # repo:sirixdb/sirix

--- a/labeled_data/technology/database/relational.yml
+++ b/labeled_data/technology/database/relational.yml
@@ -108,6 +108,7 @@ data:
     - 7502247 # repo:lealone/Lealone
     - 543276238 # repo:libsql/libsql
     - 509396909 # repo:lingo-db/lingo-db
+    - 323389945 # repo:logicalclocks/rondb
     - 23013460 # repo:lsst/qserv
     - 61153677 # repo:m3db/m3
     - 564689243 # repo:man-group/ArcticDB


### PR DESCRIPTION
Fix https://github.com/X-lab2017/open-digger/issues/1433

Batch label data: Incrementally add labels in **202311** to the database technology repository.

Filter conditions:

- Collected by dbdb.io on **Nov 29, 2023** OR Rankings in the DB-Engines Rankings table on **Nov 29, 2023**;
- Has open source license;
- Has repository link on GitHub;
- The **increment** relative to the version https://github.com/X-lab2017/open-digger/issues/1416 on **Oct 27, 2023**.

Features:

- Add new repositories with labels in [Document, Relational].

Notes: 

-  Add reason: 1 multi-labeled; 3 newly added.
