### PR TITLE
Update data for Database technical area labled on dbdb.io and DB-Engines Ranking by Dec 30, 2023.

### DIFF
--- a/labeled_data/technology/database/array.yml
+++ b/labeled_data/technology/database/array.yml
@@ -9,16 +9,16 @@ data:
           name: EuclidOLAP/EuclidOLAP
         - id: 86868560
           name: TileDB-Inc/TileDB
-        - id: 17699493
-          name: cran/scidb
+        - id: 31373521
+          name: autermann/scidb
         - id: 96580430
           name: datajaguar/jaguardb
-        - id: 5407611
-          name: dioptre/rasdaman
         - id: 664133375
           name: epsilla-cloud/vectordb
         - id: 45732002
           name: jnidzwetzki/bboxdb
+        - id: 489656726
+          name: onefanwu/RasDaMan-v10.0
         - id: 162765004
           name: peermaps/eyros
         - id: 156942199

--- a/labeled_data/technology/database/document.yml
+++ b/labeled_data/technology/database/document.yml
@@ -11,6 +11,8 @@ data:
           name: AlaSQL/alasql
         - id: 61179047
           name: Alachisoft/NosDB
+        - id: 32611526
+          name: AnantLabs/terrastore
         - id: 522606931
           name: Anna-Team/AnnaDB
         - id: 396867188
@@ -23,6 +25,8 @@ data:
           name: FerretDB/FerretDB
         - id: 605189726
           name: FgForrest/evitaDB
+        - id: 404610048
+          name: Fl1yd/LightDB
         - id: 8313554
           name: Greg0/Lazer-Database
         - id: 10296238
@@ -35,6 +39,8 @@ data:
           name: LinkedInAttic/sensei
         - id: 646427433
           name: LonaDB/Hadro
+        - id: 50098469
+          name: Nexedi/neoppod
         - id: 188354257
           name: SequoiaDB/SequoiaDB
         - id: 474070793
@@ -87,6 +93,8 @@ data:
           name: couchbase/couchbase-lite-core
         - id: 9342529
           name: crate/crate
+        - id: 722117815
+          name: cursusdb/cursusdb
         - id: 249981301
           name: dappkit/aviondb
         - id: 4732384
@@ -161,8 +169,8 @@ data:
           name: oberasoftware/jasdb
         - id: 3788366
           name: openlink/virtuoso-opensource
-        - id: 192418550
-          name: oracle/nosql-go-sdk
+        - id: 298920362
+          name: oracle/nosql-java-sdk
         - id: 48617634
           name: orbitdb/orbit-db
         - id: 7083240
@@ -225,6 +233,8 @@ data:
           name: textileio/go-threads
         - id: 449924556
           name: tigrisdata/tigris
+        - id: 597066476
+          name: tontinton/dbeel
         - id: 86339169
           name: torodb/server
         - id: 184711
@@ -245,5 +255,7 @@ data:
           name: xtdb/xtdb
         - id: 456549280
           name: ydb-platform/ydb
+        - id: 574588439
+          name: ytsaurus/ytsaurus
         - id: 47479424
           name: zerodb/zerodb

--- a/labeled_data/technology/database/graph.yml
+++ b/labeled_data/technology/database/graph.yml
@@ -17,6 +17,8 @@ data:
           name: PureSolTechnologies/DuctileDB
         - id: 84458512
           name: RedisGraph/RedisGraph
+        - id: 43494700
+          name: SparsityTechnologies/sparksee-server
         - id: 22475123
           name: amark/gun
         - id: 276293034
@@ -45,10 +47,14 @@ data:
           name: dyedgreen/cqlite
         - id: 668673665
           name: falkordb/falkordb
+        - id: 74678263
+          name: fanjinfei/grapheekdb
         - id: 305513242
           name: fluree/db
         - id: 47973088
           name: gchq/Gaffer
+        - id: 207484782
+          name: gurneyalex/cubicweb
         - id: 38727503
           name: hypergraphdb/hypergraphdb
         - id: 166429903
@@ -67,6 +73,8 @@ data:
           name: neo4j/neo4j
         - id: 7083240
           name: orientechnologies/orientdb
+        - id: 26917250
+          name: pkumod/gStore
         - id: 166387176
           name: polypheny/Polypheny-DB
         - id: 131763823

--- a/labeled_data/technology/database/key_value.yml
+++ b/labeled_data/technology/database/key_value.yml
@@ -11,6 +11,8 @@ data:
           name: AlticeLabsProjects/kyoto
         - id: 12991321
           name: Amaury/AngstromDB
+        - id: 10650868
+          name: Amaury/FineDB
         - id: 17826843
           name: AntidoteDB/antidote
         - id: 396867188
@@ -31,6 +33,8 @@ data:
           name: LMDB/lmdb
         - id: 259542436
           name: LineairDB/LineairDB
+        - id: 953500
+          name: LuaDist/tokyocabinet
         - id: 7085128
           name: Nanolat/nldb
         - id: 8103021
@@ -107,6 +111,8 @@ data:
           name: cbd/edis
         - id: 150013328
           name: cberner/redb
+        - id: 26826806
+          name: cloudflarearchive/kyotocabinet
         - id: 220186120
           name: codenotary/immudb
         - id: 69400326
@@ -127,14 +133,14 @@ data:
           name: developit/histore
         - id: 80087836
           name: dgraph-io/badger
-        - id: 3115025
-          name: dlitz/resin
         - id: 437245741
           name: dragonflydb/dragonfly
         - id: 17224514
           name: ehcache/ehcache3
         - id: 393005910
           name: engula/engula
+        - id: 44061596
+          name: erthink/libmdbx
         - id: 278320002
           name: estraier/tkrzw
         - id: 94593596
@@ -145,6 +151,8 @@ data:
           name: facebook/rocksdb
         - id: 70541093
           name: facebookarchive/beringei
+        - id: 74678263
+          name: fanjinfei/grapheekdb
         - id: 606800919
           name: firstbatchxyz/hollowdb
         - id: 292049131
@@ -187,6 +195,8 @@ data:
           name: jakekgrog/GhostDB
         - id: 5453989
           name: jankotek/mapdb
+        - id: 3914539
+          name: jbarham/cdb
         - id: 547593
           name: jingwei/krati
         - id: 37932930
@@ -209,28 +219,36 @@ data:
           name: mbdavid/FileDB
         - id: 5494148
           name: mchidk/BinaryRage
+        - id: 3596087
+          name: mdaniel/svn-caucho-com-resin
         - id: 184981
           name: memcached/memcached
         - id: 331747853
           name: microsoft/Extensible-Storage-Engine
         - id: 143253020
           name: microsoft/FASTER
+        - id: 143239
+          name: mitchellh/lightcloud
         - id: 1372117
           name: nathanmarz/elephantdb
+        - id: 149145424
+          name: nextgres/oss-haildb
         - id: 4211523
           name: oleiade/Elevator
         - id: 12106192
           name: oleiade/trousseau
         - id: 242776849
           name: oracle/coherence
-        - id: 192418550
-          name: oracle/nosql-go-sdk
+        - id: 298920362
+          name: oracle/nosql-java-sdk
         - id: 48617634
           name: orbitdb/orbit-db
         - id: 7083240
           name: orientechnologies/orientdb
         - id: 606125384
           name: paypal/junodb
+        - id: 6714651
+          name: perchouli/codernitydb
         - id: 278684767
           name: petermattis/pebble
         - id: 502268740
@@ -279,6 +297,8 @@ data:
           name: scalien/scaliendb
         - id: 28449431
           name: scylladb/scylla
+        - id: 1499938
+          name: shino/kai
         - id: 121126549
           name: simerplaha/SwayDB
         - id: 276042304

--- a/labeled_data/technology/database/multivalue.yml
+++ b/labeled_data/technology/database/multivalue.yml
@@ -5,13 +5,13 @@ data:
     - name: GitHub
       type: Code Hosting
       repos:
-        - id: 17699493
-          name: cran/scidb
-        - id: 5407611
-          name: dioptre/rasdaman
+        - id: 31373521
+          name: autermann/scidb
         - id: 1984888
           name: gregjurman/openqm
         - id: 34215181
           name: jrmarino/AdaBase
+        - id: 489656726
+          name: onefanwu/RasDaMan-v10.0
         - id: 61269853
           name: vanilladb/vanillacore

--- a/labeled_data/technology/database/network.yml
+++ b/labeled_data/technology/database/network.yml
@@ -5,5 +5,7 @@ data:
     - name: GitHub
       type: Code Hosting
       repos:
+        - id: 531145841
+          name: igor-bul/vyhodb
         - id: 10153163
           name: priitj/whitedb

--- a/labeled_data/technology/database/object_oriented.yml
+++ b/labeled_data/technology/database/object_oriented.yml
@@ -7,6 +7,8 @@ data:
       repos:
         - id: 107504377
           name: ADBSQL/AntDB
+        - id: 37905036
+          name: Alachisoft/TayzGrid
         - id: 681142
           name: Bobris/BTDB
         - id: 52080367
@@ -21,6 +23,8 @@ data:
           name: ModeShape/modeshape
         - id: 150752008
           name: SapphireDb/SapphireDb
+        - id: 43494700
+          name: SparsityTechnologies/sparksee-server
         - id: 124423054
           name: The-Alchemist/perst
         - id: 569871553
@@ -29,6 +33,8 @@ data:
           name: apache/jackrabbit
         - id: 246343828
           name: atoti/atoti
+        - id: 40787594
+          name: aur-archive/gigabase
         - id: 396856161
           name: authzed/spicedb
         - id: 644742603
@@ -39,20 +45,28 @@ data:
           name: edgedb/edgedb
         - id: 15001136
           name: etoile/CoreObject
+        - id: 145843258
+          name: eyedb/eyedb
         - id: 42143916
           name: fern4lvarez/piladb
         - id: 240387847
           name: gaia-platform/GaiaPlatform
+        - id: 32137101
+          name: google-code-export/twig-persist
         - id: 48279725
           name: goshawkdb/server
         - id: 204261394
           name: iboxdb/db4o-gpl
         - id: 5453989
           name: jankotek/mapdb
+        - id: 37340459
+          name: jayhopeter/NDatabase
         - id: 119234782
           name: jonahharris/osdb-beaglesql
         - id: 1776883
           name: kimchy/compass
+        - id: 89699591
+          name: magma-database/magma
         - id: 25225465
           name: markmeeus/MarcelloDB
         - id: 273564373
@@ -71,9 +85,15 @@ data:
           name: pipelinedb/pipelinedb
         - id: 927442
           name: postgres/postgres
+        - id: 90349373
+          name: profanedb/ProfaneDB
         - id: 1917262
           name: realm/realm-core
+        - id: 16457385
+          name: sirlordt/NeoDatis
         - id: 3893984
           name: tzaeschke/zoodb
+        - id: 107304517
+          name: wware/FramerD
         - id: 7357595
           name: zopefoundation/ZODB

--- a/labeled_data/technology/database/rdf.yml
+++ b/labeled_data/technology/database/rdf.yml
@@ -9,6 +9,8 @@ data:
           name: 4store/4store
         - id: 8335020
           name: BrightstarDB/BrightstarDB
+        - id: 6235870
+          name: ansell/openrdf-sesame
         - id: 7437073
           name: apache/jena
         - id: 111333972
@@ -29,6 +31,8 @@ data:
           name: esarbanis/strabon
         - id: 305513242
           name: fluree/db
+        - id: 207484782
+          name: gurneyalex/cubicweb
         - id: 754873
           name: njh/redstore
         - id: 16710751

--- a/labeled_data/technology/database/relational.yml
+++ b/labeled_data/technology/database/relational.yml
@@ -41,6 +41,8 @@ data:
           name: GlareDB/glaredb
         - id: 345982729
           name: GreatSQL/GreatSQL
+        - id: 274000765
+          name: GunterMueller/LEAP_RDBMS
         - id: 516821813
           name: HydrasDB/hydra
         - id: 858418
@@ -107,6 +109,8 @@ data:
           name: apavlo/h-store
         - id: 134193743
           name: apavlo/metalbase
+        - id: 40787594
+          name: aur-archive/gigabase
         - id: 143436277
           name: baidu/BaikalDB
         - id: 141378316
@@ -145,6 +149,8 @@ data:
           name: cozodb/cozo
         - id: 132361668
           name: cswinter/LocustDB
+        - id: 14090388
+          name: cznic/ql
         - id: 302827809
           name: datafuselabs/databend
         - id: 52507351
@@ -171,6 +177,8 @@ data:
           name: erikgrinaker/toydb
         - id: 59475316
           name: eventql/eventql
+        - id: 196702393
+          name: eyalroz/c-store
         - id: 388946490
           name: facebookincubator/velox
         - id: 40127179
@@ -181,6 +189,8 @@ data:
           name: fluree/db
         - id: 600860
           name: fosslc/Ingres
+        - id: 29210020
+          name: gavioto/fastdb
         - id: 148087762
           name: georgia-tech-db/eva
         - id: 3084708
@@ -307,6 +317,8 @@ data:
           name: stellarsql/StellarSQL
         - id: 12067343
           name: stephentu/silo
+        - id: 11734713
+          name: stewartsmith/drizzle
         - id: 436658287
           name: surrealdb/surrealdb
         - id: 591304097
@@ -331,6 +343,8 @@ data:
           name: vectorengine/vectorsql
         - id: 11008207
           name: vitessio/vitess
+        - id: 3900741
+          name: wundrian/csql
         - id: 19503320
           name: yaledb/calvin
         - id: 456549280

--- a/labeled_data/technology/database/spatial.yml
+++ b/labeled_data/technology/database/spatial.yml
@@ -5,6 +5,8 @@ data:
     - name: GitHub
       type: Code Hosting
       repos:
+        - id: 34533675
+          name: apache/sedona
         - id: 93667206
           name: geomesa/geomesa-geoserver
         - id: 7171304

--- a/labeled_data/technology/database/time_series.yml
+++ b/labeled_data/technology/database/time_series.yml
@@ -35,6 +35,8 @@ data:
           name: kairosdb/kairosdb
         - id: 61153677
           name: m3db/m3
+        - id: 584240610
+          name: machbase/neo-server
         - id: 5761553
           name: oetiker/rrdtool-1.x
         - id: 507829396


### PR DESCRIPTION
Fix https://github.com/X-lab2017/open-digger/issues/1457

Batch label data: Incrementally add labels in **202312** to the database technology repository.

Filter conditions:

- Collected by dbdb.io on **Dec 30, 2023** OR Rankings in the DB-Engines Rankings table on **Dec 30, 2023**;
- Has open source license;
- Has repository link on GitHub;
- The **increment** relative to the version https://github.com/X-lab2017/open-digger/issues/1433 on **Nov 29, 2023**.

Features:

- Add new repositories with labels in [Array, Document, Graph, Key-value, Multivalue, Network, Object Oriented, RDF, Relational, Spatial, Time Series].

Notes: 

-  Add or update reasons: newly added and find some similar dbms repositories with greater influence.
