### PR TITLE
fix: fix 2 bugs in cron task

### DIFF
--- a/src/cron/tasks/monthly_export.ts
+++ b/src/cron/tasks/monthly_export.ts
@@ -480,7 +480,7 @@ const task: Task = {
     const exportUserInfo = async () => {
       let processedCount = 0;
       const userInfoQuery = `SELECT platform, b.actor_login, a.location, a.bio, a.name, a.company FROM
-    (SELECT 'GitHub' AS platform, id, location, bio, name, company FROM gh_user_info WHERE status='normal')a
+    (SELECT CAST('GitHub','Enum8(\\\'GitHub\\\'=1)') AS platform, id, location, bio, name, company FROM gh_user_info WHERE status='normal')a
     LEFT JOIN
     (SELECT id, platform, actor_login FROM ${exportUserTableName})b
     ON a.id = b.id AND a.platform = b.platform`;

--- a/src/cron/tasks/open_leaderboard.ts
+++ b/src/cron/tasks/open_leaderboard.ts
@@ -12,7 +12,9 @@ const task: Task = {
 
     logger.info(`Start to run open leaderboard task.`);
 
-    const startYear = 2015, startMonth = 1, endYear = new Date().getFullYear(), endMonth = new Date().getMonth();
+    const startYear = 2015, startMonth = 1, now = new Date();
+    now.setMonth(now.getMonth() - 1);
+    const endYear = now.getFullYear(), endMonth = now.getMonth() + 1;
     const limit = 300;
     const allMonthes: string[] = [];
     await forEveryMonth(startYear, startMonth, endYear, endMonth, async (y, m) => allMonthes.push(`${y}${m}`));


### PR DESCRIPTION
Fix 2 minor bugs in cron task:

- Task `open_leaderboard`, end year and month configuration is not correct, will encounter error on a new year.
- Task `monthly_export`, while exporting user info, injected platform in SQL should be cast to Enum type explicitly. 