### PR TITLE
fix: fix platform error in sofastack

### DIFF
--- a/labeled_data/companies/antgroup/sofastack.yml
+++ b/labeled_data/companies/antgroup/sofastack.yml
@@ -7,7 +7,7 @@ data:
       orgs:
         - id: 36956638
           name: sofastack
-    - name: GitHub
+    - name: Gitee
       type: Code Hosting
       orgs:
         - id: 1861256


### PR DESCRIPTION
Fix platform name error for Sofastack label.