### PR TITLE
Fix Bug: Correct labels of yaml files in labeled_data directory.

### DIFF
--- a/labeled_data/technology/ai/generative_ai/application/audio.yml
+++ b/labeled_data/technology/ai/generative_ai/application/audio.yml
@@ -1,5 +1,5 @@
 name: Artificial Intelligence - application - audio
-type: Tech-1
+type: Tech-3
 data:
   platforms:
     - name: GitHub

--- a/labeled_data/technology/ai/generative_ai/application/audio.yml
+++ b/labeled_data/technology/ai/generative_ai/application/audio.yml
@@ -1,4 +1,4 @@
-name: Artificial Intelligence - application - audio
+name: Artificial Intelligence - Generative Artificial Intelligence - Application - Audio
 type: Tech-3
 data:
   platforms:

--- a/labeled_data/technology/ai/generative_ai/application/code.yml
+++ b/labeled_data/technology/ai/generative_ai/application/code.yml
@@ -1,5 +1,5 @@
 name: Artificial Intelligence - application - code
-type: Tech-1
+type: Tech-3
 data:
   platforms:
     - name: GitHub

--- a/labeled_data/technology/ai/generative_ai/application/code.yml
+++ b/labeled_data/technology/ai/generative_ai/application/code.yml
@@ -1,4 +1,4 @@
-name: Artificial Intelligence - application - code
+name: Artificial Intelligence - Generative Artificial Intelligence - Application - Code
 type: Tech-3
 data:
   platforms:

--- a/labeled_data/technology/ai/generative_ai/application/image.yml
+++ b/labeled_data/technology/ai/generative_ai/application/image.yml
@@ -1,4 +1,4 @@
-name: Artificial Intelligence - application - image
+name: Artificial Intelligence - Generative Artificial Intelligence - Application - Image
 type: Tech-3
 data:
   platforms:

--- a/labeled_data/technology/ai/generative_ai/application/image.yml
+++ b/labeled_data/technology/ai/generative_ai/application/image.yml
@@ -1,5 +1,5 @@
 name: Artificial Intelligence - application - image
-type: Tech-1
+type: Tech-3
 data:
   platforms:
     - name: GitHub

--- a/labeled_data/technology/ai/generative_ai/application/index.yml
+++ b/labeled_data/technology/ai/generative_ai/application/index.yml
@@ -1,4 +1,4 @@
-name: Application
+name: Artificial Intelligence - Generative Artificial Intelligence - Application
 type: Tech-2
 data:
   labels:

--- a/labeled_data/technology/ai/generative_ai/application/index.yml
+++ b/labeled_data/technology/ai/generative_ai/application/index.yml
@@ -1,6 +1,13 @@
 name: Application
-type: Tech-1
+type: Tech-2
 data:
+  labels:
+    - audio
+    - code
+    - image
+    - text
+    - other
+    - video
   platforms:
     - name: GitHub
       type: Code Hosting

--- a/labeled_data/technology/ai/generative_ai/application/other.yml
+++ b/labeled_data/technology/ai/generative_ai/application/other.yml
@@ -1,4 +1,4 @@
-name: Artificial Intelligence - application - other
+name: Artificial Intelligence - Generative Artificial Intelligence - Application - Other
 type: Tech-3
 data:
   platforms:

--- a/labeled_data/technology/ai/generative_ai/application/other.yml
+++ b/labeled_data/technology/ai/generative_ai/application/other.yml
@@ -1,5 +1,5 @@
 name: Artificial Intelligence - application - other
-type: Tech-1
+type: Tech-3
 data:
   platforms:
     - name: GitHub

--- a/labeled_data/technology/ai/generative_ai/application/text.yml
+++ b/labeled_data/technology/ai/generative_ai/application/text.yml
@@ -1,5 +1,5 @@
 name: Artificial Intelligence - application - text
-type: Tech-1
+type: Tech-3
 data:
   platforms:
     - name: GitHub

--- a/labeled_data/technology/ai/generative_ai/application/text.yml
+++ b/labeled_data/technology/ai/generative_ai/application/text.yml
@@ -1,4 +1,4 @@
-name: Artificial Intelligence - application - text
+name: Artificial Intelligence - Generative Artificial Intelligence - Application - Text
 type: Tech-3
 data:
   platforms:

--- a/labeled_data/technology/ai/generative_ai/application/video.yml
+++ b/labeled_data/technology/ai/generative_ai/application/video.yml
@@ -1,5 +1,5 @@
 name: Artificial Intelligence - application - video
-type: Tech-1
+type: Tech-3
 data:
   platforms:
     - name: GitHub

--- a/labeled_data/technology/ai/generative_ai/application/video.yml
+++ b/labeled_data/technology/ai/generative_ai/application/video.yml
@@ -1,4 +1,4 @@
-name: Artificial Intelligence - application - video
+name: Artificial Intelligence - Generative Artificial Intelligence - Application - Video
 type: Tech-3
 data:
   platforms:

--- a/labeled_data/technology/ai/generative_ai/index.yml
+++ b/labeled_data/technology/ai/generative_ai/index.yml
@@ -5,6 +5,7 @@ data:
     - model
     - tool
     - application
+    - infrastructure
   platforms:
     - name: GitHub
       type: Code Hosting

--- a/labeled_data/technology/ai/generative_ai/infrastructure/data.yml
+++ b/labeled_data/technology/ai/generative_ai/infrastructure/data.yml
@@ -1,4 +1,4 @@
-name: Artificial Intelligence - infrastructure - data
+name: Artificial Intelligence - Generative Artificial Intelligence - Infrastructure - Data
 type: Tech-3
 data:
   platforms:

--- a/labeled_data/technology/ai/generative_ai/infrastructure/data.yml
+++ b/labeled_data/technology/ai/generative_ai/infrastructure/data.yml
@@ -1,5 +1,5 @@
 name: Artificial Intelligence - infrastructure - data
-type: Tech-1
+type: Tech-3
 data:
   platforms:
     - name: GitHub

--- a/labeled_data/technology/ai/generative_ai/infrastructure/document.yml
+++ b/labeled_data/technology/ai/generative_ai/infrastructure/document.yml
@@ -1,5 +1,5 @@
 name: Artificial Intelligence - infrastructure - document
-type: Tech-1
+type: Tech-3
 data:
   platforms:
     - name: GitHub

--- a/labeled_data/technology/ai/generative_ai/infrastructure/document.yml
+++ b/labeled_data/technology/ai/generative_ai/infrastructure/document.yml
@@ -1,4 +1,4 @@
-name: Artificial Intelligence - infrastructure - document
+name: Artificial Intelligence - Generative Artificial Intelligence - Infrastructure - Document
 type: Tech-3
 data:
   platforms:

--- a/labeled_data/technology/ai/generative_ai/infrastructure/index.yml
+++ b/labeled_data/technology/ai/generative_ai/infrastructure/index.yml
@@ -1,0 +1,8 @@
+name: Infrastructure
+type: Tech-2
+data:
+  labels:
+    - data
+    - document
+    - platform_and_environment
+    - vector_database

--- a/labeled_data/technology/ai/generative_ai/infrastructure/index.yml
+++ b/labeled_data/technology/ai/generative_ai/infrastructure/index.yml
@@ -1,4 +1,4 @@
-name: Infrastructure
+name: Artificial Intelligence - Generative Artificial Intelligence - Infrastructure
 type: Tech-2
 data:
   labels:

--- a/labeled_data/technology/ai/generative_ai/infrastructure/platform_and_environment.yml
+++ b/labeled_data/technology/ai/generative_ai/infrastructure/platform_and_environment.yml
@@ -1,4 +1,4 @@
-name: Artificial Intelligence - infrastructure - platform & environment
+name: Artificial Intelligence - Generative Artificial Intelligence - Infrastructure - Platform & Environment
 type: Tech-3
 data:
   platforms:

--- a/labeled_data/technology/ai/generative_ai/infrastructure/platform_and_environment.yml
+++ b/labeled_data/technology/ai/generative_ai/infrastructure/platform_and_environment.yml
@@ -1,5 +1,5 @@
 name: Artificial Intelligence - infrastructure - platform & environment
-type: Tech-1
+type: Tech-3
 data:
   platforms:
     - name: GitHub

--- a/labeled_data/technology/ai/generative_ai/infrastructure/vector_database.yml
+++ b/labeled_data/technology/ai/generative_ai/infrastructure/vector_database.yml
@@ -1,5 +1,5 @@
 name: Artificial Intelligence - infrastructure - vector database
-type: Tech-1
+type: Tech-3
 data:
   platforms:
     - name: GitHub

--- a/labeled_data/technology/ai/generative_ai/infrastructure/vector_database.yml
+++ b/labeled_data/technology/ai/generative_ai/infrastructure/vector_database.yml
@@ -1,4 +1,4 @@
-name: Artificial Intelligence - infrastructure - vector database
+name: Artificial Intelligence - Generative Artificial Intelligence - Infrastructure - Vector Database
 type: Tech-3
 data:
   platforms:

--- a/labeled_data/technology/ai/generative_ai/model/framework_and_architecture.yml
+++ b/labeled_data/technology/ai/generative_ai/model/framework_and_architecture.yml
@@ -1,4 +1,4 @@
-name: Artificial Intelligence - model - framework & architecture
+name: Artificial Intelligence - Generative Artificial Intelligence - Model - Framework & Architecture
 type: Tech-3
 data:
   platforms:

--- a/labeled_data/technology/ai/generative_ai/model/framework_and_architecture.yml
+++ b/labeled_data/technology/ai/generative_ai/model/framework_and_architecture.yml
@@ -1,5 +1,5 @@
 name: Artificial Intelligence - model - framework & architecture
-type: Tech-1
+type: Tech-3
 data:
   platforms:
     - name: GitHub

--- a/labeled_data/technology/ai/generative_ai/model/fundamental_model.yml
+++ b/labeled_data/technology/ai/generative_ai/model/fundamental_model.yml
@@ -1,5 +1,5 @@
 name: Artificial Intelligence - model - fundamental model
-type: Tech-1
+type: Tech-3
 data:
   platforms:
     - name: GitHub

--- a/labeled_data/technology/ai/generative_ai/model/fundamental_model.yml
+++ b/labeled_data/technology/ai/generative_ai/model/fundamental_model.yml
@@ -1,4 +1,4 @@
-name: Artificial Intelligence - model - fundamental model
+name: Artificial Intelligence - Generative Artificial Intelligence - Model - Fundamental Model
 type: Tech-3
 data:
   platforms:

--- a/labeled_data/technology/ai/generative_ai/model/index.yml
+++ b/labeled_data/technology/ai/generative_ai/model/index.yml
@@ -1,4 +1,4 @@
-name: Model
+name: Artificial Intelligence - Generative Artificial Intelligence - Model
 type: Tech-2
 data:
   labels:

--- a/labeled_data/technology/ai/generative_ai/model/index.yml
+++ b/labeled_data/technology/ai/generative_ai/model/index.yml
@@ -1,6 +1,10 @@
 name: Model
-type: Tech-1
+type: Tech-2
 data:
+  labels:
+    - framework_and_architecture
+    - fundamental_model
+    - variant_model
   platforms:
     - name: GitHub
       type: Code Hosting

--- a/labeled_data/technology/ai/generative_ai/model/variant_model.yml
+++ b/labeled_data/technology/ai/generative_ai/model/variant_model.yml
@@ -1,4 +1,4 @@
-name: Artificial Intelligence - model - variant model
+name: Artificial Intelligence - Generative Artificial Intelligence - Model - Variant Model
 type: Tech-3
 data:
   platforms:

--- a/labeled_data/technology/ai/generative_ai/model/variant_model.yml
+++ b/labeled_data/technology/ai/generative_ai/model/variant_model.yml
@@ -1,5 +1,5 @@
 name: Artificial Intelligence - model - variant model
-type: Tech-1
+type: Tech-3
 data:
   platforms:
     - name: GitHub

--- a/labeled_data/technology/ai/generative_ai/tool/deployment_tool.yml
+++ b/labeled_data/technology/ai/generative_ai/tool/deployment_tool.yml
@@ -1,4 +1,4 @@
-name: Artificial Intelligence - tool - deployment tool
+name: Artificial Intelligence - Generative Artificial IntellIgence - Tool - Deployment Tool
 type: Tech-3
 data:
   platforms:

--- a/labeled_data/technology/ai/generative_ai/tool/deployment_tool.yml
+++ b/labeled_data/technology/ai/generative_ai/tool/deployment_tool.yml
@@ -1,5 +1,5 @@
 name: Artificial Intelligence - tool - deployment tool
-type: Tech-1
+type: Tech-3
 data:
   platforms:
     - name: GitHub

--- a/labeled_data/technology/ai/generative_ai/tool/develop_tool.yml
+++ b/labeled_data/technology/ai/generative_ai/tool/develop_tool.yml
@@ -1,5 +1,5 @@
 name: Artificial Intelligence - tool - develop tool
-type: Tech-1
+type: Tech-3
 data:
   platforms:
     - name: GitHub

--- a/labeled_data/technology/ai/generative_ai/tool/develop_tool.yml
+++ b/labeled_data/technology/ai/generative_ai/tool/develop_tool.yml
@@ -1,4 +1,4 @@
-name: Artificial Intelligence - tool - develop tool
+name: Artificial Intelligence - Generative Artificial Intelligence - Tool - Develop Tool
 type: Tech-3
 data:
   platforms:

--- a/labeled_data/technology/ai/generative_ai/tool/index.yml
+++ b/labeled_data/technology/ai/generative_ai/tool/index.yml
@@ -1,6 +1,11 @@
 name: Tool
-type: Tech-1
+type: Tech-2
 data:
+  labels:
+    - deployment_tool
+    - develop_tool
+    - production_monitor
+    - prompt_engineering
   platforms:
     - name: GitHub
       type: Code Hosting

--- a/labeled_data/technology/ai/generative_ai/tool/index.yml
+++ b/labeled_data/technology/ai/generative_ai/tool/index.yml
@@ -1,4 +1,4 @@
-name: Tool
+name: Artificial Intelligence - Generative Artificial Intelligence - Tool
 type: Tech-2
 data:
   labels:

--- a/labeled_data/technology/ai/generative_ai/tool/production_monitor.yml
+++ b/labeled_data/technology/ai/generative_ai/tool/production_monitor.yml
@@ -1,4 +1,4 @@
-name: Artificial Intelligence - production monitor
+name: Artificial Intelligence - GenerAtive Artificial Intelligence - Tool - Production Monitor
 type: Tech-3
 data:
   platforms:

--- a/labeled_data/technology/ai/generative_ai/tool/production_monitor.yml
+++ b/labeled_data/technology/ai/generative_ai/tool/production_monitor.yml
@@ -1,5 +1,5 @@
 name: Artificial Intelligence - production monitor
-type: Tech-1
+type: Tech-3
 data:
   platforms:
     - name: GitHub

--- a/labeled_data/technology/ai/generative_ai/tool/prompt_engineering.yml
+++ b/labeled_data/technology/ai/generative_ai/tool/prompt_engineering.yml
@@ -1,5 +1,5 @@
 name: Artificial Intelligence - tool - prompt engineering
-type: Tech-1
+type: Tech-3
 data:
   platforms:
     - name: GitHub

--- a/labeled_data/technology/ai/generative_ai/tool/prompt_engineering.yml
+++ b/labeled_data/technology/ai/generative_ai/tool/prompt_engineering.yml
@@ -1,4 +1,4 @@
-name: Artificial Intelligence - tool - prompt engineering
+name: Artificial Intelligence - Generative Artificial InteLligence - Tool - Prompt Engineering
 type: Tech-3
 data:
   platforms:

--- a/labeled_data/technology/ai/large_language_model/index.yml
+++ b/labeled_data/technology/ai/large_language_model/index.yml
@@ -1,5 +1,5 @@
-name: Large Language Model
-type: Tech-0
+name: Artificial Intelligence - Large Language Model
+type: Tech-1
 data:
   platforms:
     - name: GitHub

--- a/labeled_data/technology/cloud_native/app_definition_and_development/application_definition_and_image_build.yml
+++ b/labeled_data/technology/cloud_native/app_definition_and_development/application_definition_and_image_build.yml
@@ -1,5 +1,4 @@
-name: Cloud Native - App Definition and Development - Application Definition &
-  Image Build
+name: Cloud Native - App Definition and Development - Application Definition & Image Build
 type: Tech-2
 data:
   platforms:

--- a/labeled_data/technology/cloud_native/app_definition_and_development/continuous_integration_and_delivery.yml
+++ b/labeled_data/technology/cloud_native/app_definition_and_development/continuous_integration_and_delivery.yml
@@ -1,5 +1,4 @@
-name: Cloud Native - App Definition and Development - Continuous Integration &
-  Delivery
+name: Cloud Native - App Definition and Development - Continuous Integration & Delivery
 type: Tech-2
 data:
   platforms:

--- a/labeled_data/technology/cloud_native/platform/certified_kubernetes_distribution.yml
+++ b/labeled_data/technology/cloud_native/platform/certified_kubernetes_distribution.yml
@@ -1,4 +1,4 @@
-name: Cloud Native - Platform - Certified Kubernetes - Distribution
+name: Cloud Native - Platform - Certified Kubernetes Distribution
 type: Tech-2
 data:
   platforms:

--- a/labeled_data/technology/cloud_native/platform/certified_kubernetes_hosted.yml
+++ b/labeled_data/technology/cloud_native/platform/certified_kubernetes_hosted.yml
@@ -1,4 +1,4 @@
-name: Cloud Native - Platform - Certified Kubernetes - Hosted
+name: Cloud Native - Platform - Certified Kubernetes Hosted
 type: Tech-2
 data:
   platforms:

--- a/labeled_data/technology/cloud_native/platform/certified_kubernetes_installer.yml
+++ b/labeled_data/technology/cloud_native/platform/certified_kubernetes_installer.yml
@@ -1,4 +1,4 @@
-name: Cloud Native - Platform - Certified Kubernetes - Installer
+name: Cloud Native - Platform - Certified Kubernetes Installer
 type: Tech-2
 data:
   platforms:

--- a/src/label_data_utils.ts
+++ b/src/label_data_utils.ts
@@ -9,7 +9,7 @@ const labelInputPath = path.join(__dirname, labelInputDir);
 
 const checkKeysAndTypes = {
   labelTypes: new Set<string>([
-    'Region', 'Company', 'Community', 'Project', 'Foundation', 'Tech-0', 'Tech-1', 'Tech-2', 'Domain-0', 'Bot'
+    'Region', 'Company', 'Community', 'Project', 'Foundation', 'Tech-0', 'Tech-1', 'Tech-2', 'Tech-3', 'Domain-0', 'Bot'
   ]),
   labelKeys: new Set<string>([
     'labels', 'platforms'


### PR DESCRIPTION
Fix https://github.com/X-lab2017/open-digger/issues/1484

# Purpose

- Fix miss counting bug: Add the untracked categories into its parent node index.yml label list.
- Fix mixed counting bug: Change the 'Tech-N' label to match the default template: increase N from root node to leaf node based on depth.

# Changes

Notes: *.yml files mentioned below do not including index.yml.
- Fix miss counting bug in [:technology](https://github.com/X-lab2017/open-digger/tree/master/labeled_data/technology)`: 
  - Add missing index.yml: `:technology/ai/generative_ai/infrastructure/index.yml .
  - Add 3rd depth `:technology/ai/generative_ai/infrastructure/*.yml` into `:technology/ai/generative_ai/infrastructure/index.yml` label list; 
  - Add 3rd depth `:technology/ai/generative_ai/application/*.yml` into `:technology/ai/generative_ai/application/index.yml` label list.
  - Add 3rd depth `:technology/ai/generative_ai/model/*.yml` into `:technology/ai/generative_ai/model/index.yml` label list.
  - Add 3rd depth `:technology/ai/generative_ai/tool/*.yml` into `:technology/ai/generative_ai/tool/index.yml` label list.
  
- Fix mixed counting bug in [:technology](https://github.com/X-lab2017/open-digger/tree/master/labeled_data/technology): 
  - Change 3rd depth leaf files `:technology/ai/generative_ai/*/*.yml` type to `Tech-3`
  - Change 3rd depth leaf files `:technology/ai/generative_ai/*/index.yml` type to `Tech-2` to represent the categories in 2rd depth directories `:technology/ai/generative_ai/*/`
  - Change 2nd depth leaf files `:technology/ai/large_language_model/index.yml` type to `Tech-1` to represent the categories in 1st depth directories `:technology/ai/large_language_model/`.
  - Add supported label type Tech-3 into [label_data_utils.ts](https://github.com/X-lab2017/open-digger/blob/master/src/label_data_utils.ts).

# Default Settings

Current depth defination: The sub-directories `:technology/*` in `[:technology](https://github.com/X-lab2017/open-digger/tree/master/labeled_data/technology)` is 0th layer, and its label type is in the `:technology/*/index.yml`  under it with the format `type: Tech-0`. The type level of subordinate files increases gradually by depth.

