### PR TITLE
refactor: some minor refactors

### DIFF
--- a/src/metrics/basic.ts
+++ b/src/metrics/basic.ts
@@ -31,11 +31,13 @@ export interface QueryConfig<T = any> {
 };
 
 export const getMergedConfig = (config: any): QueryConfig => {
+  const now = new Date();
+  now.setMonth(now.getMonth() - 1);
   const defaultConfig: QueryConfig = {
     startYear: 2015,
     startMonth: 1,
-    endYear: new Date().getFullYear(),
-    endMonth: new Date().getMonth(),
+    endYear: now.getFullYear(),
+    endMonth: now.getMonth() + 1,
     orderOption: 'latest',
     limit: 10,
     limitOption: 'all',

--- a/src/open_digger.js
+++ b/src/open_digger.js
@@ -78,23 +78,6 @@ const openDigger = {
       };
     });
   },
-  quick: {
-    showAll: (repoName, startYear = 2015, endYear = 2021) => {
-      openDigger.driver.neo4j.query(`MATCH (r:Repo{name:'${repoName}'}) RETURN r;`).then(data => {
-        const values = [
-          { y: [], mode: 'scatter', name: 'activity' },
-          { y: [], mode: 'scatter', name: 'openrank' }];
-        for (let year = startYear; year <= endYear; year++) {
-          for (let month = 1; month <= 12; month++) {
-            const k = `${year}${month}`;
-            values[0].y.push(data[0][`activity_${k}`]);
-            values[1].y.push(data[0][`open_rank_${k}`]);
-          }
-        }
-        openDigger.render.plotly(values, { title: `Activity/OpenRank for ${repoName} from ${startYear} to ${endYear}` });
-      });
-    }
-  }
 }
 
 module.exports = openDigger;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -77,12 +77,11 @@ export function rankData<T = any>(data: T[], iterArr: any[], getter: (item: T, i
 }
 
 export const getLogger = (tag: string) => {
+  const log = (level: string, ...args: any[]) =>
+    console.log(`${dateformat(new Date(), 'yyyy-mm-dd HH:MM:ss')} ${level} [${tag}]`, ...args);
   return {
-    info: (...args: any[]) =>
-      console.log(`${dateformat(new Date(), 'yyyy-mm-dd HH:MM:ss', true)} INFO [${tag}]`, ...args),
-    warn: (...args: any[]) =>
-      console.log(`${dateformat(new Date(), 'yyyy-mm-dd HH:MM:ss', true)} WARN [${tag}]`, ...args),
-    error: (...args: any[]) =>
-      console.log(`${dateformat(new Date(), 'yyyy-mm-dd HH:MM:ss', true)} ERROR [${tag}]`, ...args),
+    info: (...args: any[]) => log('INFO', ...args),
+    warn: (...args: any[]) => log('WARN', ...args),
+    error: (...args: any[]) => log('ERROR', ...args),
   };
 };


### PR DESCRIPTION
Refactor some minor places:

- Remove `openDigger.quick` API which is deprecated.
- Refactor `getLogger` function, make sure the time printed is for current timezone now but not UTC.
- Fix `getMergedConfig` with `endYear` and `endMonth` default value which is not correct for Jan. right now.