### PR TITLE
Update data for Database technical area labled on dbdb.io and DB-Engines Ranking by Jan 28, 2024.

### DIFF
--- a/labeled_data/technology/database/key_value.yml
+++ b/labeled_data/technology/database/key_value.yml
@@ -233,6 +233,8 @@ data:
           name: nathanmarz/elephantdb
         - id: 149145424
           name: nextgres/oss-haildb
+        - id: 722854801
+          name: oasysai/oasysdb
         - id: 4211523
           name: oleiade/Elevator
         - id: 12106192

--- a/labeled_data/technology/database/vector.yml
+++ b/labeled_data/technology/database/vector.yml
@@ -27,6 +27,8 @@ data:
           name: milvus-io/milvus
         - id: 478288303
           name: nuclia/nucliadb
+        - id: 722854801
+          name: oasysai/oasysdb
         - id: 40127179
           name: pilosa/pilosa
         - id: 268163609


### PR DESCRIPTION
Fix https://github.com/X-lab2017/open-digger/issues/1517

Batch label data: Incrementally add labels in April to the database technology repository.
Update Data: Update labeled data of Opensource DBMS with a github repo link based on dbdb.io and DB-Engines by Jan 28, 2024. 

**Filter conditions**: 
- Collected by dbdb.io on Jan 28, 2024 OR Rankings in the DB-Engines Rankings table on Jan 28, 2024; 
- Has open source license; 
- Has repository link on GitHub; 
- The increment relative to the version https://github.com/X-lab2017/open-digger/issues/1457 on Dec 30, 2023.

Features:
- Add 1 repo "oasysai/oasysdb" with multi-labels: ["Key-value", "Vector"].