### PR TITLE
Update data for Database technical area labled on dbdb.io and DB-Engines Ranking by Feb 29, 2024.

### DIFF
--- a/labeled_data/technology/database/document.yml
+++ b/labeled_data/technology/database/document.yml
@@ -135,6 +135,8 @@ data:
           name: jedisct1/Pincaster
         - id: 635374751
           name: jina-ai/vectordb
+        - id: 270858421
+          name: juji-io/datalevin
         - id: 632269609
           name: kagisearch/vectordb
         - id: 1776883
@@ -217,6 +219,8 @@ data:
           name: sirixdb/sirix
         - id: 295745510
           name: small-tech/jsdb
+        - id: 192631273
+          name: sourcenetwork/defradb
         - id: 436658287
           name: surrealdb/surrealdb
         - id: 22761491

--- a/labeled_data/technology/database/relational.yml
+++ b/labeled_data/technology/database/relational.yml
@@ -19,8 +19,6 @@ data:
           name: ByConity/ByConity
         - id: 52080367
           name: CUBRID/cubrid
-        - id: 496505424
-          name: CeresDB/ceresdb
         - id: 60246359
           name: ClickHouse/ClickHouse
         - id: 129072319
@@ -89,6 +87,8 @@ data:
           name: apache/hive
         - id: 56128733
           name: apache/impala
+        - id: 496505424
+          name: apache/incubator-horaedb
         - id: 56214719
           name: apache/incubator-retired-quickstep
         - id: 50647838


### PR DESCRIPTION
Fix https://github.com/X-lab2017/open-digger/issues/1528

Batch label data: Incrementally add labels in April to the database technology repository.
Update Data: Update labeled data of Opensource DBMS with a github repo link based on dbdb.io and DB-Engines by Feb 29, 2024. 

**Filter conditions**: 
- Collected by dbdb.io on Feb 29, 2024 OR Rankings in the DB-Engines Rankings table on Feb 29, 2024; 
- Has open source license; 
- Has repository link on GitHub; 
- The increment relative to the version https://github.com/X-lab2017/open-digger/issues/1517 on Jan 28, 2024.

Features:
- Add 3 repositories with labels in ["Relational", "Document"].
- Delete 1 repository "CeresDB/ceresdb" for the datebase CeresDB can no longer be retrieved by [dbdb.io](https://www.dbdb.io/).