### PR TITLE
Update data for Database technical area labled on dbdb.io and DB-Engines Ranking up to Mar 31, 2024.

### DIFF
--- a/labeled_data/technology/database/document.yml
+++ b/labeled_data/technology/database/document.yml
@@ -37,8 +37,8 @@ data:
           name: Kinto/kinto
         - id: 533032
           name: LinkedInAttic/sensei
-        - id: 646427433
-          name: LonaDB/Hadro
+        - id: 750864017
+          name: LonaDB/Server
         - id: 50098469
           name: Nexedi/neoppod
         - id: 188354257

--- a/labeled_data/technology/database/key_value.yml
+++ b/labeled_data/technology/database/key_value.yml
@@ -227,6 +227,8 @@ data:
           name: microsoft/Extensible-Storage-Engine
         - id: 143253020
           name: microsoft/FASTER
+        - id: 681372871
+          name: microsoft/garnet
         - id: 143239
           name: mitchellh/lightcloud
         - id: 1372117
@@ -339,6 +341,8 @@ data:
           name: tonsky/datascript
         - id: 223895357
           name: tuxmonk/pupdb
+        - id: 775743011
+          name: valkey-io/valkey
         - id: 179588377
           name: vinniefalco/NuDB
         - id: 385356389

--- a/labeled_data/technology/database/relational.yml
+++ b/labeled_data/technology/database/relational.yml
@@ -55,6 +55,8 @@ data:
           name: Mckoi/origsqldb
         - id: 316690542
           name: MonetDB/MonetDB
+        - id: 684046299
+          name: OpenTenBase/OpenTenBase
         - id: 41443810
           name: Postgres-XL/Postgres-XL
         - id: 74375185
@@ -127,6 +129,8 @@ data:
           name: canonical/dqlite
         - id: 372181547
           name: cashapp/pranadb
+        - id: 606433492
+          name: chdb-io/chdb
         - id: 50874442
           name: citusdata/citus
         - id: 644742603


### PR DESCRIPTION
Fix https://github.com/X-lab2017/open-digger/issues/1543

Batch label data: Incrementally add labeled repositories into the database technology.
Update Data: Update labeled data of Opensource DBMS with a github repo link based on dbdb.io and DB-Engines up to Mar 31, 2024. 

**Filter conditions**: 
- Collected by dbdb.io on Mar 31, 2024 OR Rankings in the DB-Engines Rankings table on Mar 31, 2024; 
- Has open source license; 
- Has repository link on GitHub; 
- The increment relative to the version https://github.com/X-lab2017/open-digger/issues/1528 on Feb 29, 2024.

Features:
- Add 4 new repositories with labels in ["Relational", "Document", "Key-value"].
- Update 1 repository github link to "LonaDB/Server".