### PR TITLE
Update data for Database technical area labled on dbdb.io and DB-Engines Ranking up to Apr 30, 2024.

### DIFF
--- a/labeled_data/technology/database/array.yml
+++ b/labeled_data/technology/database/array.yml
@@ -23,3 +23,5 @@ data:
           name: peermaps/eyros
         - id: 156942199
           name: perone/euclidesdb
+        - id: 90768966
+          name: uwdb/lightdb

--- a/labeled_data/technology/database/document.yml
+++ b/labeled_data/technology/database/document.yml
@@ -113,6 +113,8 @@ data:
           name: endatabas/endb
         - id: 14143348
           name: fakemongo/fongo
+        - id: 679889516
+          name: fireproof-storage/fireproof
         - id: 305513242
           name: fluree/db
         - id: 138411034

--- a/labeled_data/technology/database/graph.yml
+++ b/labeled_data/technology/database/graph.yml
@@ -19,6 +19,8 @@ data:
           name: RedisGraph/RedisGraph
         - id: 43494700
           name: SparsityTechnologies/sparksee-server
+        - id: 528766495
+          name: TuGraph-family/tugraph-db
         - id: 22475123
           name: amark/gun
         - id: 276293034

--- a/labeled_data/technology/database/key_value.yml
+++ b/labeled_data/technology/database/key_value.yml
@@ -291,6 +291,8 @@ data:
           name: roma/roma
         - id: 318972528
           name: roseduan/rosedb
+        - id: 779811016
+          name: sabledb-io/sabledb
         - id: 34056205
           name: sachin-sinha/BangDB
         - id: 354659748

--- a/labeled_data/technology/database/object_oriented.yml
+++ b/labeled_data/technology/database/object_oriented.yml
@@ -65,6 +65,8 @@ data:
           name: jonahharris/osdb-beaglesql
         - id: 1776883
           name: kimchy/compass
+        - id: 442441933
+          name: mabel-dev/opteryx
         - id: 89699591
           name: magma-database/magma
         - id: 25225465

--- a/labeled_data/technology/database/relational.yml
+++ b/labeled_data/technology/database/relational.yml
@@ -61,6 +61,8 @@ data:
           name: Postgres-XL/Postgres-XL
         - id: 74375185
           name: RedBeardLab/rediSQL
+        - id: 574694308
+          name: RhizomeDB/rs-rhizome
         - id: 42580991
           name: SnappyDataInc/snappydata
         - id: 402945349
@@ -183,6 +185,8 @@ data:
           name: eventql/eventql
         - id: 196702393
           name: eyalroz/c-store
+        - id: 172208960
+          name: eztools-software/FileDb
         - id: 388946490
           name: facebookincubator/velox
         - id: 40127179
@@ -237,6 +241,8 @@ data:
           name: lsst/qserv
         - id: 61153677
           name: m3db/m3
+        - id: 442441933
+          name: mabel-dev/opteryx
         - id: 564689243
           name: man-group/ArcticDB
         - id: 95614931
@@ -277,6 +283,8 @@ data:
           name: pinusdb/pinusdb
         - id: 14702444
           name: pipelinedb/pipelinedb
+        - id: 618452402
+          name: plabayo/venndb
         - id: 510607652
           name: pocketbase/pocketbase
         - id: 166387176

--- a/labeled_data/technology/database/time_series.yml
+++ b/labeled_data/technology/database/time_series.yml
@@ -5,6 +5,8 @@ data:
     - name: GitHub
       type: Code Hosting
       repos:
+        - id: 346976717
+          name: 4paradigm/OpenMLDB
         - id: 396867188
           name: ArcadeData/arcadedb
         - id: 480217156

--- a/labeled_data/technology/database/vector.yml
+++ b/labeled_data/technology/database/vector.yml
@@ -5,6 +5,8 @@ data:
     - name: GitHub
       type: Code Hosting
       repos:
+        - id: 753244287
+          name: DeployQL/LintDB
         - id: 201403923
           name: activeloopai/deeplake
         - id: 642912355
@@ -29,6 +31,8 @@ data:
           name: nuclia/nucliadb
         - id: 722854801
           name: oasysai/oasysdb
+        - id: 735283134
+          name: philippgille/chromem-go
         - id: 40127179
           name: pilosa/pilosa
         - id: 268163609


### PR DESCRIPTION
Fix https://github.com/X-lab2017/open-digger/issues/1551

Batch label data: Incrementally add labeled repositories into the database technology.
Update Data: Update labeled data of Opensource DBMS with a github repo link based on dbdb.io and DB-Engines up to Apr 30, 2024. 

**Filter conditions**: 
- Collected by dbdb.io on Apr 30, 2024 OR Rankings in the DB-Engines Rankings table on Apr 30, 2024; 
- Has open source license; 
- Has repository link on GitHub; 
- The increment relative to the version https://github.com/X-lab2017/open-digger/issues/1543 on Mar 31, 2024.

Features:
- Add 12 new repositories with labels in ["Array", "Document", "Graph", "Key-value", "Object Oriented", "Relational", "Time Series", "Vector"].