### PR TITLE
Update data for Database technical area labled on dbdb.io and DB-Engines Ranking up to May 30, 2024.

### DIFF
--- a/labeled_data/technology/database/document.yml
+++ b/labeled_data/technology/database/document.yml
@@ -109,6 +109,8 @@ data:
           name: earthstar-project/earthstar
         - id: 507775
           name: elastic/elasticsearch
+        - id: 411979983
+          name: elmarti/camadb
         - id: 587246478
           name: endatabas/endb
         - id: 14143348

--- a/labeled_data/technology/database/key_value.yml
+++ b/labeled_data/technology/database/key_value.yml
@@ -351,12 +351,16 @@ data:
           name: vmware/splinterdb
         - id: 214605
           name: voldemort/voldemort
+        - id: 580788054
+          name: web3-storage/pail
         - id: 30828379
           name: willemt/pearldb
         - id: 2944302
           name: wiredtiger/wiredtiger
         - id: 65259211
           name: xap/xap
+        - id: 20433978
+          name: xtreemfs/babudb
         - id: 160784930
           name: xujiajun/nutsdb
         - id: 137792810

--- a/labeled_data/technology/database/object_oriented.yml
+++ b/labeled_data/technology/database/object_oriented.yml
@@ -71,6 +71,8 @@ data:
           name: magma-database/magma
         - id: 25225465
           name: markmeeus/MarcelloDB
+        - id: 160528020
+          name: mateusfreira/nun-db
         - id: 273564373
           name: morecraf/Siaqodb
         - id: 351806852

--- a/labeled_data/technology/database/relational.yml
+++ b/labeled_data/technology/database/relational.yml
@@ -67,6 +67,8 @@ data:
           name: SnappyDataInc/snappydata
         - id: 402945349
           name: StarRocks/StarRocks
+        - id: 590507334
+          name: StereoDB/StereoDB
         - id: 501460708
           name: StoneAtom/stonedb
         - id: 2445970
@@ -99,6 +101,8 @@ data:
           name: apache/kudu
         - id: 28738447
           name: apache/kylin
+        - id: 114619105
+          name: apache/kyuubi
         - id: 20473418
           name: apache/phoenix
         - id: 19961085

--- a/labeled_data/technology/database/time_series.yml
+++ b/labeled_data/technology/database/time_series.yml
@@ -51,6 +51,8 @@ data:
           name: rackerlabs/blueflood
         - id: 135549948
           name: radicalbit/NSDb
+        - id: 441299511
+          name: reductstore/reductstore
         - id: 50594316
           name: senx/warp10-platform
         - id: 15682781

--- a/labeled_data/technology/database/vector.yml
+++ b/labeled_data/technology/database/vector.yml
@@ -11,6 +11,8 @@ data:
           name: activeloopai/deeplake
         - id: 642912355
           name: awa-ai/awadb
+        - id: 793209340
+          name: carsonpo/haystackdb
         - id: 546206616
           name: chroma-core/chroma
         - id: 304530333


### PR DESCRIPTION
Fix https://github.com/X-lab2017/open-digger/issues/1573

Batch label data: Incrementally add labeled repositories into the database technology.
Update Data: Update labeled data of Opensource DBMS with a github repo link based on dbdb.io and DB-Engines up to May 30, 2024. 

**Filter conditions**: 
- Collected by dbdb.io on May 30, 2024 OR Rankings in the DB-Engines Rankings table on May 30, 2024; 
- Has open source license; 
- Has repository link on GitHub; 
- The increment relative to the version https://github.com/X-lab2017/open-digger/issues/1551 on Apr 30, 2024.

Features:
- Add 8 new repositories with labels in ["Document", "Key-value", "Object Oriented", "Relational", "Time Series", "Vector"].