### PR TITLE
Update data for Database technical area labled on dbdb.io and DB-Engines Ranking up to June 30, 2024.

### DIFF
--- a/labeled_data/technology/database/document.yml
+++ b/labeled_data/technology/database/document.yml
@@ -197,6 +197,12 @@ data:
           name: priitj/whitedb
         - id: 75425073
           name: pubkey/rxdb
+        - id: 416174776
+          name: pysonDB/pysonDB-v2
+        - id: 357707809
+          name: quickwit-oss/quickwit
+        - id: 49412556
+          name: quickwit-oss/tantivy
         - id: 5665061
           name: radare/sdb
         - id: 129436009

--- a/labeled_data/technology/database/object_oriented.yml
+++ b/labeled_data/technology/database/object_oriented.yml
@@ -83,6 +83,8 @@ data:
           name: orientechnologies/orientdb
         - id: 432844875
           name: orioledb/orioledb
+        - id: 660776503
+          name: paradedb/paradedb
         - id: 37285717
           name: pilgr/Paper
         - id: 14702444

--- a/labeled_data/technology/database/relational.yml
+++ b/labeled_data/technology/database/relational.yml
@@ -261,6 +261,8 @@ data:
           name: minovakovi/akdb
         - id: 62660036
           name: mozilla/mentat
+        - id: 771847852
+          name: myscale/MyScaleDB
         - id: 24494032
           name: mysql/mysql-server
         - id: 351806852
@@ -275,6 +277,8 @@ data:
           name: opengauss-mirror/openGauss-server
         - id: 432844875
           name: orioledb/orioledb
+        - id: 660776503
+          name: paradedb/paradedb
         - id: 3766330
           name: pentaho/mondrian
         - id: 30753733


### PR DESCRIPTION
Fix https://github.com/X-lab2017/open-digger/issues/1582

Batch label data: Incrementally add labeled repositories into the database technology.
Update Data: Update labeled data of Opensource DBMS with a github repo link based on dbdb.io and DB-Engines up to June 30, 2024. 

**Filter conditions**: 
- Collected by dbdb.io on June 30, 2024 OR Rankings in the DB-Engines Rankings table on June 30, 2024; 
- Has open source license; 
- Has repository link on GitHub; 
- The increment relative to the version https://github.com/X-lab2017/open-digger/issues/1573 on May 30, 2024.

Features:
- Add 7 new repositories with labels in ["Document", "Object Oriented", "Relational"].