### PR TITLE
Update data for Database technical area labled on dbdb.io and DB-Engines Ranking up to July 31, 2024.

### DIFF
--- a/labeled_data/technology/database/graph.yml
+++ b/labeled_data/technology/database/graph.yml
@@ -100,6 +100,6 @@ data:
         - id: 605999
           name: twitter-archive/flockdb
         - id: 63110867
-          name: vaticle/typedb
+          name: typedb/typedb
         - id: 146459443
           name: vesoft-inc/nebula

--- a/labeled_data/technology/database/relational.yml
+++ b/labeled_data/technology/database/relational.yml
@@ -211,6 +211,8 @@ data:
           name: gnocchixyz/gnocchi
         - id: 24650236
           name: google/lovefield
+        - id: 385634291
+          name: grafana/mimir
         - id: 44781140
           name: greenplum-db/gpdb
         - id: 33745913


### PR DESCRIPTION
Fix https://github.com/X-lab2017/open-digger/issues/1599

Batch label data: Incrementally add labeled repositories into the database technology.
Update Data: Update labeled data of Opensource DBMS with a github repo link based on dbdb.io and DB-Engines up to July 31, 2024. 

**Filter conditions**: 
- Collected by dbdb.io on July 31, 2024 OR Rankings in the DB-Engines Rankings table on July 31, 2024; 
- Has open source license; 
- Has repository link on GitHub; 
- The increment relative to the version https://github.com/X-lab2017/open-digger/issues/1583 on June 30, 2024.

Features:
- Update 1 repository name with labels in ["Graph"].
- Add 1 new repository with labels in ["Relational"].