### PR TITLE
Update data for Database technical area labled on dbdb.io and DB-Engines Ranking up to August 29, 2024 and update database/index.yml.

### DIFF
--- a/labeled_data/technology/database/columnar.yml
+++ b/labeled_data/technology/database/columnar.yml
@@ -1,0 +1,9 @@
+name: Database - Columnar
+type: Tech-1
+data:
+  platforms:
+    - name: GitHub
+      type: Code Hosting
+      repos:
+        - id: 170496871
+          name: gridgain/gridgain

--- a/labeled_data/technology/database/document.yml
+++ b/labeled_data/technology/database/document.yml
@@ -57,8 +57,8 @@ data:
           name: apache/drill
         - id: 341631350
           name: apache/lucene
-        - id: 341374920
-          name: apache/solr
+        - id: 50229487
+          name: apache/lucene-solr
         - id: 114187903
           name: apple/foundationdb
         - id: 137869753
@@ -139,6 +139,8 @@ data:
           name: jedisct1/Pincaster
         - id: 635374751
           name: jina-ai/vectordb
+        - id: 811062736
+          name: joswayski/averagedatabase
         - id: 270858421
           name: juji-io/datalevin
         - id: 632269609

--- a/labeled_data/technology/database/index.yml
+++ b/labeled_data/technology/database/index.yml
@@ -3,6 +3,7 @@ type: Tech-0
 data:
   labels:
     - array
+    - columnar
     - content
     - document
     - event

--- a/labeled_data/technology/database/key_value.yml
+++ b/labeled_data/technology/database/key_value.yml
@@ -23,6 +23,8 @@ data:
           name: BohuTANG/nessDB
         - id: 8799170
           name: DevrexLabs/OrigoDB
+        - id: 840308148
+          name: Gifted-s/velarixdb
         - id: 344711168
           name: IceFireDB/IceFireDB
         - id: 3019304
@@ -111,6 +113,8 @@ data:
           name: cbd/edis
         - id: 150013328
           name: cberner/redb
+        - id: 747399975
+          name: chromodb/chromodb
         - id: 26826806
           name: cloudflarearchive/kyotocabinet
         - id: 220186120
@@ -165,8 +169,6 @@ data:
           name: goossaert/kingdb
         - id: 52420005
           name: griddb/griddb
-        - id: 170496871
-          name: gridgain/gridgain
         - id: 154541438
           name: gruns/ImmortalDB
         - id: 2272541

--- a/labeled_data/technology/database/search_engine.yml
+++ b/labeled_data/technology/database/search_engine.yml
@@ -5,8 +5,8 @@ data:
     - name: GitHub
       type: Code Hosting
       repos:
-        - id: 341374920
-          name: apache/solr
+        - id: 50229487
+          name: apache/lucene-solr
         - id: 507775
           name: elastic/elasticsearch
         - id: 95614931

--- a/labeled_data/technology/database/wide_column.yml
+++ b/labeled_data/technology/database/wide_column.yml
@@ -7,6 +7,8 @@ data:
       repos:
         - id: 316690542
           name: MonetDB/MonetDB
+        - id: 402945349
+          name: StarRocks/StarRocks
         - id: 150954997
           name: VictoriaMetrics/VictoriaMetrics
         - id: 2524488


### PR DESCRIPTION
Fix https://github.com/X-lab2017/open-digger/issues/1610

Batch label data: Incrementally add labeled repositories into the database technology.
Update Data: 
  - Update labeled data of Opensource DBMS with a github repo link based on dbdb.io and DB-Engines up to August 29, 2024. 
  - **Update database/index.yml**: import the new label "Columnar" from DB-Engines.

**Filter conditions**: 
- Collected by dbdb.io on August 29, 2024 OR Rankings in the DB-Engines Rankings table on August 29, 2024; 
- Has open source license; 
- Has repository link on GitHub; 
- The increment relative to the version https://github.com/X-lab2017/open-digger/issues/1599 on July 31, 2024.

Features:
- Add 1 new label "Columnar" imported from DB-Engines into database/index.yml.
- Update 1 repository name with labels in ["Document", "Search Engine"].
- Move "gridgain/gridgain" from "Key-value" to "Columnar".
- Add 4 new repositories with labels in ["Document", "Key-value", "Wide column"].