### PR TITLE
feat: change open leaderboard user list to community openrank

### DIFF
--- a/labeled_data/bot/index.yml
+++ b/labeled_data/bot/index.yml
@@ -1487,6 +1487,72 @@ data:
           name: bambootest-bot
         - id: 87254977
           name: ahmar7
+        - id: 171268329
+          name: DigitalPlatFoundation
+        - id: 77073439
+          name: webkit-commit-queue
+        - id: 28621316
+          name: NordicBuilder
+        - id: 14542386
+          name: gentoo-bot
+        - id: 58790826
+          name: elasticsearchmachine
+        - id: 10336601
+          name: daocloudpublic
+        - id: 92915184
+          name: airbyteio
+        - id: 76178356
+          name: OSBotify
+        - id: 101608348
+          name: llamatester
+        - id: 17281578
+          name: yugabyte-ci
+        - id: 45043797
+          name: nixos-discourse
+        - id: 47979223
+          name: rustbot
+        - id: 110908925
+          name: bot-gitexp-user
+        - id: 120460335
+          name: pix-bot-github
+        - id: 69588470
+          name: posthog-bot
+        - id: 97558700
+          name: mui-bot
+        - id: 152529449
+          name: bot2-harness
+        - id: 43204447
+          name: app-sre-bot
+        - id: 115476073
+          name: Satellite-QE
+        - id: 177514479
+          name: BambulabRobot
+        - id: 48055056
+          name: ch-code-analysis
+        - id: 41093903
+          name: sysopenci
+        - id: 137281497
+          name: bcbuild-github-agent
+        - id: 115160210
+          name: cloud-platform-concourse-bot
+        - id: 58012459
+          name: llvm-ci
+        - id: 111915794
+          name: gravity-ui-bot
+        - id: 129911861
+          name: leanprover-community-mathlib4-bot
+        - id: 37885440
+          name: metamaskbot
+        - id: 75649378
+          name: modernappsninjabot
+        - id: 58891217
+          name: bazel-flag-bot
+        - id: 46904574
+          name: flinkbot
+        - id: 39309875
+          name: spinnakerbot
+        - id: 40367165
+          name: asf-ci
     - name: Gitee
       type: Code Hosting
       users:


### PR DESCRIPTION
This PR:

- Add a few more bot account
- Use user community OpenRank instead of user global OpenRank in OpenLeaderboard.
- To accomplish the second one, add `withoutDetail` option to user community OpenRank interface to reduce the memory use.
- Still the monthly data for global user OpenRank is too memory consuming for ClickHouse database so split the query to batches and merge in local memory.