### PR TITLE
fix: fix milvus label to has a single source

### DIFF
--- a/labeled_data/foundations/linux_foundation/lfai/index.yml
+++ b/labeled_data/foundations/linux_foundation/lfai/index.yml
@@ -17,7 +17,6 @@ data:
     - delta_lake
     - docarrary
     - janusgraph
-    - milvus
     - amundsen
     - datashim
     - marquez
@@ -45,3 +44,4 @@ data:
     - adversarial_robustness_toolkit
     - ai_fairness_360_toolkit
     - open_voice_trustmark
+    - :companies/zilliz/milvus

--- a/labeled_data/foundations/linux_foundation/lfai/milvus.yml
+++ b/labeled_data/foundations/linux_foundation/lfai/milvus.yml
@@ -1,9 +1,0 @@
-name: Milvus
-type: Project
-data:
-  platforms:
-    - name: GitHub
-      type: Code Hosting
-      orgs:
-        - id: 51735404
-          name: milvus-io


### PR DESCRIPTION
If a project label has more than 1 source, the project result will be wrong and contain more than 1 same item.

So fix the milvus label, the AI tech label will directly use the company's project label.