### PR TITLE
refactor: optimize the openrank sql

### DIFF
--- a/src/metrics/basic.ts
+++ b/src/metrics/basic.ts
@@ -109,7 +109,7 @@ export const getRepoWhereClause = async (config: QueryConfig): Promise<string | 
     for (const p of config.idOrNames) {
       if (p.repoNames && p.repoNames.length > 0) {
         // convert repo name to id
-        const sql = `SELECT any(repo_id) AS id FROM events WHERE repo_name IN [${p.repoNames.map(n => `'${n}'`)}] AND platform='${p.platform}' GROUP BY repo_name`;
+        const sql = `SELECT any(repo_id) AS id FROM global_openrank WHERE repo_name IN [${p.repoNames.map(n => `'${n}'`)}] AND platform='${p.platform}' GROUP BY repo_name`;
         const repoIds = (await query<any>(sql, { format: 'JSONEachRow' })).map(r => r.id);
         repoWhereClauseArray.push(`(repo_id IN [${repoIds.join(',')}] AND platform='${p.platform}')`);
       }
@@ -118,7 +118,7 @@ export const getRepoWhereClause = async (config: QueryConfig): Promise<string | 
 
       if (p.orgNames && p.orgNames.length > 0) {
         // convert org name to id
-        const sql = `SELECT any(org_id) AS id FROM events WHERE org_login IN [${p.orgNames.map(n => `'${n}'`)}] AND platform='${p.platform}' GROUP BY org_login`;
+        const sql = `SELECT any(org_id) AS id FROM global_openrank WHERE org_login IN [${p.orgNames.map(n => `'${n}'`)}] AND platform='${p.platform}' GROUP BY org_login`;
         const orgIds = (await query<any>(sql, { format: 'JSONEachRow' })).map(r => r.id);
         repoWhereClauseArray.push(`(org_id IN [${orgIds.join(',')}] AND platform='${p.platform}')`);
       }
@@ -169,7 +169,7 @@ export const getUserWhereClause = async (config: QueryConfig, idCol: string = 'a
     for (const p of config.idOrNames) {
       if (p.userLogins && p.userLogins.length > 0) {
         // convert user login to id
-        const sql = `SELECT any(actor_id) AS id FROM events WHERE actor_login IN [${p.userLogins.map(n => `'${n}'`)}] AND platform='${p.platform}' GROUP BY actor_login`;
+        const sql = `SELECT any(actor_id) AS id FROM global_openrank WHERE actor_login IN [${p.userLogins.map(n => `'${n}'`)}] AND platform='${p.platform}' GROUP BY actor_login`;
         const userIds = (await query<any>(sql, { format: 'JSONEachRow' })).map(r => r.id);
         userWhereClauseArray.push(`(${idCol} IN [${userIds.join(',')}] AND platform='${p.platform}')`);
       }

--- a/src/metrics/indices.ts
+++ b/src/metrics/indices.ts
@@ -179,6 +179,10 @@ export const getUserCommunityOpenrank = async (config: QueryConfig<UserCommunity
   const repoWhereClause = await getRepoWhereClause(config);
   if (repoWhereClause) whereClause.push(repoWhereClause);
   const userWhereClause = await getUserWhereClause(config, 'id');
+  const innerUserWhereClause = await getUserWhereClause(config);
+  if (innerUserWhereClause) {
+    whereClause.push(`repo_id IN (SELECT repo_id FROM community_openrank WHERE ${innerUserWhereClause})`);
+  }
   const timeRangeClause = getTimeRangeWhereClause(config);
   if (timeRangeClause) whereClause.push(timeRangeClause);
   const limit = (config.options?.limit == undefined) ? 30 : config.options.limit;


### PR DESCRIPTION
This PR,

- Optimize the custom repo names, org names and user logins transfer to ids, only use `global_openrank` table rather than original `events` table which is much faster.
- Optimize the user community OpenRank API, filter the original data with user ids which helps a lot in memory consumption.