### PR TITLE
refactor: add legacy limit for openrank interface.

### DIFF
--- a/src/metrics/indices.ts
+++ b/src/metrics/indices.ts
@@ -29,7 +29,7 @@ export const getRepoOpenrank = async (config: QueryConfig) => {
   if (repoWhereClause) whereClause.push(repoWhereClause);
   const timeRangeClause = getTimeRangeWhereClause(config);
   if (timeRangeClause) whereClause.push(timeRangeClause);
-  whereClause.push("type='Repo'");
+  whereClause.push("type='Repo' AND legacy=0");
 
   const sql = `
 SELECT
@@ -61,7 +61,7 @@ export const getUserOpenrank = async (config: QueryConfig) => {
   if (userWhereClause) whereClause.push(userWhereClause);
   const timeRangeClause = getTimeRangeWhereClause(config);
   if (timeRangeClause) whereClause.push(timeRangeClause);
-  whereClause.push("type='User'");
+  whereClause.push("type='User' AND legacy=0");
 
   const sql = `
 SELECT


### PR DESCRIPTION
Add `legacy=0` for user and repo OpenRank interface.

Since `legacy=1` means the record is a legacy result, and it means that the repo or user did not really active in current month, only calculate the result by history data with attenuation.

In OpenLeaderboard and other related application, we should not really care about the inactive repos and users, so add the limitation in the interface to filter the legacy records.