### PR TITLE
label: Update data for Database technical area labled on dbdb.io and DB-Engines Ranking up to October 31, 2024.

### DIFF
--- a/labeled_data/technology/database/document.yml
+++ b/labeled_data/technology/database/document.yml
@@ -121,6 +121,8 @@ data:
           name: fluree/db
         - id: 138411034
           name: genjidb/genji
+        - id: 852516379
+          name: goshops-com/StormiDB
         - id: 285669400
           name: graphikDB/graphik
         - id: 12050336

--- a/labeled_data/technology/database/key_value.yml
+++ b/labeled_data/technology/database/key_value.yml
@@ -137,6 +137,8 @@ data:
           name: developit/histore
         - id: 80087836
           name: dgraph-io/badger
+        - id: 531220682
+          name: dicedb/dice
         - id: 437245741
           name: dragonflydb/dragonfly
         - id: 17224514
@@ -311,6 +313,8 @@ data:
           name: simerplaha/SwayDB
         - id: 276042304
           name: skytable/skytable
+        - id: 777912773
+          name: slatedb/slatedb
         - id: 49401416
           name: spacejam/sled
         - id: 462329984
@@ -341,6 +345,8 @@ data:
           name: tikv/tikv
         - id: 3114475
           name: tomp2p/TomP2P
+        - id: 828742634
+          name: tonbo-io/tonbo
         - id: 18800032
           name: tonsky/datascript
         - id: 223895357

--- a/labeled_data/technology/database/relational.yml
+++ b/labeled_data/technology/database/relational.yml
@@ -21,6 +21,8 @@ data:
           name: CUBRID/cubrid
         - id: 60246359
           name: ClickHouse/ClickHouse
+        - id: 654870350
+          name: ClockworkLabs/SpacetimeDB
         - id: 129072319
           name: CovenantSQL/CovenantSQL
         - id: 151762200


### PR DESCRIPTION
Fix https://github.com/X-lab2017/open-digger/issues/1631

Batch label data: Incrementally add labeled repositories into the database technology.
Update Data: 
  - Update labeled data of Opensource DBMS with a github repo link based on dbdb.io and DB-Engines up to October 31, 2024. 

**Filter conditions**: 
- Collected by dbdb.io on October 31, 2024 OR Rankings in the DB-Engines Rankings table on October 31, 2024; 
- Has open source license; 
- Has repository link on GitHub; 
- The increment relative to the version https://github.com/X-lab2017/open-digger/issues/1610 on August 29, 2024.

Features:
- Add 5 new repositories with labels in ["Document", "Key-value", "Relational"].