### PR TITLE
label: Update data for Database technical area labled on dbdb.io and DB-Engines Ranking up to November 29, 2024.

### DIFF
--- a/labeled_data/technology/database/key_value.yml
+++ b/labeled_data/technology/database/key_value.yml
@@ -139,6 +139,8 @@ data:
           name: dgraph-io/badger
         - id: 531220682
           name: dicedb/dice
+        - id: 789424265
+          name: dmarro89/dare-db
         - id: 437245741
           name: dragonflydb/dragonfly
         - id: 17224514

--- a/labeled_data/technology/database/relational.yml
+++ b/labeled_data/technology/database/relational.yml
@@ -165,6 +165,8 @@ data:
           name: cznic/ql
         - id: 302827809
           name: datafuselabs/databend
+        - id: 2894420
+          name: deveel/deveeldb
         - id: 52507351
           name: diennea/herddb
         - id: 198683574


### PR DESCRIPTION
Fix https://github.com/X-lab2017/open-digger/issues/1653

Batch label data: Incrementally add labeled repositories into the database technology.
Update Data: 
  - Update labeled data of Opensource DBMS with a github repo link based on dbdb.io and DB-Engines up to November 29, 2024. 

**Filter conditions**: 
- Collected by dbdb.io on November 29, 2024 OR Rankings in the DB-Engines Rankings table on November 29, 2024; 
- Has open source license; 
- Has repository link on GitHub; 
- The increment relative to the version https://github.com/X-lab2017/open-digger/issues/1631 on October 31, 2024.

Features:
- Add 2 new repositories with labels in ["Key-value", "Relational"].