### PR TITLE
label: Update data for Database technical area labled on dbdb.io and DB-Engines Ranking up to December 30, 2024.

### DIFF
--- a/labeled_data/technology/database/document.yml
+++ b/labeled_data/technology/database/document.yml
@@ -38,9 +38,11 @@ data:
         - id: 533032
           name: LinkedInAttic/sensei
         - id: 750864017
-          name: LonaDB/Server
+          name: Lona-Development/Server
         - id: 50098469
           name: Nexedi/neoppod
+        - id: 284225188
+          name: PoloDB/PoloDB
         - id: 188354257
           name: SequoiaDB/SequoiaDB
         - id: 474070793
@@ -83,6 +85,8 @@ data:
           name: bluzi/jsonstore
         - id: 234091935
           name: c9fe/sirdb
+        - id: 844591313
+          name: capjamesg/jamesql
         - id: 639434928
           name: cfu288/SylvieJS
         - id: 546206616

--- a/labeled_data/technology/database/relational.yml
+++ b/labeled_data/technology/database/relational.yml
@@ -163,6 +163,8 @@ data:
           name: cswinter/LocustDB
         - id: 14090388
           name: cznic/ql
+        - id: 824462634
+          name: darshan117/BroDB
         - id: 302827809
           name: datafuselabs/databend
         - id: 2894420
@@ -217,8 +219,8 @@ data:
           name: google/lovefield
         - id: 385634291
           name: grafana/mimir
-        - id: 44781140
-          name: greenplum-db/gpdb
+        - id: 805041952
+          name: greenplum-db/gpdb-archive
         - id: 33745913
           name: h2database/h2database
         - id: 90541149

--- a/labeled_data/technology/database/wide_column.yml
+++ b/labeled_data/technology/database/wide_column.yml
@@ -43,3 +43,5 @@ data:
           name: scylladb/scylla
         - id: 41209174
           name: strapdata/elassandra
+        - id: 872645739
+          name: tidesdb/tidesdb


### PR DESCRIPTION
Fix https://github.com/X-lab2017/open-digger/issues/1664

Batch label data: Incrementally add labeled repositories into the database technology.
Update Data: 
  - Update labeled data of Opensource DBMS with a github repo link based on dbdb.io and DB-Engines up to December 30, 2024. 

**Filter conditions**: 
- Collected by dbdb.io on December 30, 2024 OR Rankings in the DB-Engines Rankings table on December 30, 2024; 
- Has open source license; 
- Has repository link on GitHub; 
- The increment relative to the version https://github.com/X-lab2017/open-digger/issues/1653 on November 29, 2024.

Features:
- Add 6 new repositories with labels in ["Document", "Relational", "Wide column"].
- 1 repo changed name: `LonaDB/Server` -> `Lona-Development/Server`
- Due to no longer being open source, 1 repo is using alternatives: `greenplum-db/gpdb` -> `greenplum-db/gpdb-archive`