### PR TITLE
label: Update data for Database technical area labled on dbdb.io and DB-Engines Ranking up to January 29, 2025.

### DIFF
--- a/labeled_data/technology/database/graph.yml
+++ b/labeled_data/technology/database/graph.yml
@@ -13,6 +13,8 @@ data:
           name: DevrexLabs/OrigoDB
         - id: 77385607
           name: JanusGraph/janusgraph
+        - id: 92834468
+          name: Pometry/Raphtory
         - id: 45098765
           name: PureSolTechnologies/DuctileDB
         - id: 84458512

--- a/labeled_data/technology/database/key_value.yml
+++ b/labeled_data/technology/database/key_value.yml
@@ -323,6 +323,8 @@ data:
           name: speedb-io/speedb
         - id: 36483902
           name: spotify/heroic
+        - id: 919276446
+          name: starskey-io/starskey
         - id: 34593732
           name: stephenmcd/curiodb
         - id: 454981666


### PR DESCRIPTION
Fix https://github.com/X-lab2017/open-digger/issues/1676

Batch label data: Incrementally add labeled repositories into the database technology.
Update Data: 
  - Update labeled data of Opensource DBMS with a github repo link based on dbdb.io and DB-Engines up to January 29, 2025. 

**Filter conditions**: 
- Collected by dbdb.io on January 29, 2025 OR Rankings in the DB-Engines Rankings table on January 29, 2025; 
- Has open source license; 
- Has repository link on GitHub; 
- The increment relative to the version https://github.com/X-lab2017/open-digger/issues/1664 on December 30, 2024.

Features:
- Add 2 new repositories with labels in ["Graph", "Key-value"].