### PR TITLE
label: Update data for Database technical area labled on dbdb.io and DB-Engines Ranking up to March 03, 2025 for the February update.

### DIFF
--- a/labeled_data/technology/database/document.yml
+++ b/labeled_data/technology/database/document.yml
@@ -191,6 +191,8 @@ data:
           name: orientechnologies/orientdb
         - id: 453191009
           name: ostafen/clover
+        - id: 207457900
+          name: patx/kenobi
         - id: 2662146
           name: patx/pickledb
         - id: 39519916

--- a/labeled_data/technology/database/graph.yml
+++ b/labeled_data/technology/database/graph.yml
@@ -105,3 +105,5 @@ data:
           name: typedb/typedb
         - id: 146459443
           name: vesoft-inc/nebula
+        - id: 759929648
+          name: youtrackdb/youtrackdb

--- a/labeled_data/technology/database/object_oriented.yml
+++ b/labeled_data/technology/database/object_oriented.yml
@@ -41,8 +41,6 @@ data:
           name: cloudberrydb/cloudberrydb
         - id: 95070401
           name: devrexlabs/memstate
-        - id: 95817032
-          name: edgedb/edgedb
         - id: 15001136
           name: etoile/CoreObject
         - id: 145843258
@@ -51,6 +49,8 @@ data:
           name: fern4lvarez/piladb
         - id: 240387847
           name: gaia-platform/GaiaPlatform
+        - id: 95817032
+          name: geldata/gel
         - id: 32137101
           name: google-code-export/twig-persist
         - id: 48279725

--- a/labeled_data/technology/database/relational.yml
+++ b/labeled_data/technology/database/relational.yml
@@ -77,6 +77,8 @@ data:
           name: VoltDB/voltdb
         - id: 416777125
           name: alexraffy/sksql
+        - id: 692348247
+          name: amelielabs/amelie
         - id: 3927863
           name: antonmks/Alenka
         - id: 358917318
@@ -179,8 +181,6 @@ data:
           name: dremio/dremio-oss
         - id: 138754790
           name: duckdb/duckdb
-        - id: 95817032
-          name: edgedb/edgedb
         - id: 341208515
           name: edgelesssys/edgelessdb
         - id: 61373806
@@ -209,6 +209,8 @@ data:
           name: fosslc/Ingres
         - id: 29210020
           name: gavioto/fastdb
+        - id: 95817032
+          name: geldata/gel
         - id: 148087762
           name: georgia-tech-db/eva
         - id: 3084708


### PR DESCRIPTION
Fix https://github.com/X-lab2017/open-digger/issues/1684

Batch label data: Incrementally add labeled repositories into the database technology.
Update Data: 
  - Update labeled data of Opensource DBMS with a github repo link based on dbdb.io and DB-Engines up to March 03, 2025. 

**Filter conditions**: 
- Collected by dbdb.io on March 03, 2025 OR Rankings in the DB-Engines Rankings table on March 03, 2025; 
- Has open source license; 
- Has repository link on GitHub; 
- The increment relative to the version https://github.com/X-lab2017/open-digger/issues/1676 on January 29, 2024.

Features:
- Update 1 repository with labels in ["Object Oriented",  "Relational"]. The updated repo_name `[from, to, reason]` list: 
[["edgedb/edgedb", "geldata/gel", owner changed to [Gel Data Inc](https://www.geldata.com/)]].
- Add 3 new repositories with labels in ["Document", "Graph", "Relational"].

Notes:
- The repo_id is queried from `repository_url` api `https://api.github.com/repos/{owner}/{repo}`.
