### PR TITLE
label: Update data for Database technical area labled on dbdb.io and DB-Engines Ranking up to March 31, 2025.

### DIFF
--- a/labeled_data/technology/database/document.yml
+++ b/labeled_data/technology/database/document.yml
@@ -155,6 +155,8 @@ data:
           name: kimchy/compass
         - id: 607441698
           name: lancedb/lancedb
+        - id: 349172057
+          name: linkedin/venice
         - id: 376679845
           name: losfair/RefineDB
         - id: 9795883


### PR DESCRIPTION
Fix https://github.com/X-lab2017/open-digger/issues/1691

Batch label data: Incrementally add labeled repositories into the database technology.
Update Data: 
  - Update labeled data of Opensource DBMS with a github repo link based on dbdb.io and DB-Engines up to March 31, 2025. 

**Filter conditions**: 
- Collected by dbdb.io on March 31, 2025 OR Rankings in the DB-Engines Rankings table on March 31, 2025; 
- Has open source license; 
- Has repository link on GitHub; 
- The increment relative to the version https://github.com/X-lab2017/open-digger/issues/1684 on March 03, 2024.

Features:
- Add 1 new repository with labels in ["Document"].

Notes:
- The changes overview: [issue_body_format_parse_github_id.txt](https://github.com/birdflyi/wiget_autogen_issue_body_for_opendigger_submiting_labeled_data_issue/blob/main/data/result/incremental_generation/curr_relative_incremental/parsed/issue_body_format_parse_github_id.txt)
- The repo_id is queried from `repository_url` api `https://api.github.com/repos/{owner}/{repo}`.
