### PR TITLE
fix: fix repo name in group clause

### DIFF
--- a/src/metrics/indices.ts
+++ b/src/metrics/indices.ts
@@ -41,7 +41,7 @@ FROM
 (
   SELECT
     ${getGroupTimeClause(config)},
-    ${getGroupIdClause(config)},
+    ${getGroupIdClause(config, 'repo', 'created_at')},
     SUM(openrank) AS openrank
   FROM global_openrank
   WHERE ${whereClause.join(' AND ')}


### PR DESCRIPTION
The repo name of OpenRank metrics are not correct for quarter or year group range, fix it by specify the time column of group time clause.