### PR TITLE
label: Update data for Database technical area labled on dbdb.io and DB-Engines Ranking up to April 30, 2025.

### DIFF
--- a/labeled_data/technology/database/document.yml
+++ b/labeled_data/technology/database/document.yml
@@ -51,6 +51,8 @@ data:
           name: Softmotions/ejdb
         - id: 8428443
           name: X2rdas/easedb
+        - id: 124315604
+          name: aerospike/aerospike-server
         - id: 31976266
           name: apache/asterixdb
         - id: 206417
@@ -125,6 +127,8 @@ data:
           name: fluree/db
         - id: 138411034
           name: genjidb/genji
+        - id: 897888926
+          name: goatplatform/goatdb
         - id: 852516379
           name: goshops-com/StormiDB
         - id: 285669400

--- a/labeled_data/technology/database/graph.yml
+++ b/labeled_data/technology/database/graph.yml
@@ -11,6 +11,8 @@ data:
           name: CulturePlex/Sylva
         - id: 8799170
           name: DevrexLabs/OrigoDB
+        - id: 893031915
+          name: HelixDB/helix-db
         - id: 77385607
           name: JanusGraph/janusgraph
         - id: 92834468

--- a/labeled_data/technology/database/vector.yml
+++ b/labeled_data/technology/database/vector.yml
@@ -7,8 +7,12 @@ data:
       repos:
         - id: 753244287
           name: DeployQL/LintDB
+        - id: 893031915
+          name: HelixDB/helix-db
         - id: 201403923
           name: activeloopai/deeplake
+        - id: 124315604
+          name: aerospike/aerospike-server
         - id: 642912355
           name: awa-ai/awadb
         - id: 793209340


### PR DESCRIPTION
Fix https://github.com/X-lab2017/open-digger/issues/1696

Batch label data: Incrementally add labeled repositories into the database technology.
Update Data: 
  - Update labeled data of Opensource DBMS with a github repo link based on dbdb.io and DB-Engines up to April 30, 2025. 

**Filter conditions**: 
- Collected by dbdb.io on April 30, 2025 OR Rankings in the DB-Engines Rankings table on April 30, 2025; 
- Has open source license; 
- Has repository link on GitHub; 
- The increment relative to the version https://github.com/X-lab2017/open-digger/issues/1691 on March 31, 2024.

Features:
- Add 3 new repositories with labels in ["Document", "Graph", "Vector"].

Notes:
- The repo_id is queried from `repository_url` api `https://api.github.com/repos/{owner}/{repo}`.
