### PR TITLE
label: Update data for Database technical area labled on dbdb.io and DB-Engines Ranking up to May 30, 2025.

### DIFF
--- a/labeled_data/technology/database/relational.yml
+++ b/labeled_data/technology/database/relational.yml
@@ -63,6 +63,8 @@ data:
           name: Postgres-XL/Postgres-XL
         - id: 74375185
           name: RedBeardLab/rediSQL
+        - id: 30113463
+          name: Remi-Coulom/joedb
         - id: 574694308
           name: RhizomeDB/rs-rhizome
         - id: 42580991
@@ -349,6 +351,8 @@ data:
           name: stephentu/silo
         - id: 11734713
           name: stewartsmith/drizzle
+        - id: 975891605
+          name: stoolap/stoolap
         - id: 436658287
           name: surrealdb/surrealdb
         - id: 591304097


### PR DESCRIPTION
Fix https://github.com/X-lab2017/open-digger/issues/1703

Batch label data: Incrementally add labeled repositories into the database technology.
Update Data: 
  - Update labeled data of Opensource DBMS with a github repo link based on dbdb.io and DB-Engines up to May 30, 2025. 

**Filter conditions**: 
- Collected by dbdb.io on May 30, 2025 OR Rankings in the DB-Engines Rankings table on May 30, 2025; 
- Has open source license; 
- Has repository link on GitHub; 
- The increment relative to the version https://github.com/X-lab2017/open-digger/issues/1696 on April 30, 2024.

Features:
- Add 2 new repositories with labels in ["Relational"].

Notes:
- The repo_id is queried from `repository_url` api `https://api.github.com/repos/{owner}/{repo}`.
