### PR TITLE
label: Update data for Database technical area labled on dbdb.io and DB-Engines Ranking up to July 31, 2025.

### DIFF
--- a/labeled_data/technology/database/key_value.yml
+++ b/labeled_data/technology/database/key_value.yml
@@ -353,6 +353,8 @@ data:
           name: tonbo-io/tonbo
         - id: 18800032
           name: tonsky/datascript
+        - id: 274611759
+          name: topling/toplingdb
         - id: 223895357
           name: tuxmonk/pupdb
         - id: 775743011

--- a/labeled_data/technology/database/relational.yml
+++ b/labeled_data/technology/database/relational.yml
@@ -229,6 +229,8 @@ data:
           name: h2database/h2database
         - id: 90541149
           name: heavyai/heavydb
+        - id: 911776933
+          name: hpides/skyrise
         - id: 291675222
           name: hstreamdb/hstream
         - id: 87414843


### PR DESCRIPTION
Fix https://github.com/X-lab2017/open-digger/issues/1709

Batch label data: Incrementally add labeled repositories into the database technology.
Update Data: 
  - Update labeled data of Opensource DBMS with a github repo link based on dbdb.io and DB-Engines up to July 31, 2025. 

**Filter conditions**: 
- Collected by dbdb.io on July 31, 2025 OR Rankings in the DB-Engines Rankings table on July 31, 2025; 
- Has open source license; 
- Has repository link on GitHub; 
- The increment relative to the version https://github.com/X-lab2017/open-digger/issues/1703 on May 30, 2024.

Features:
- Add 2 new repositories with labels in ["Key-value", "Relational"].

Notes:
- The repo_id is queried from `repository_url` api `https://api.github.com/repos/{owner}/{repo}`.
