### PR TITLE
feature: add zh readme

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -1,0 +1,25 @@
+# OpenDigger
+
+[![apache2](https://img.shields.io/badge/license-Apache%202-blue)](LICENSE) [![](https://img.shields.io/badge/Data-OpenDigger-2097FF)](https://github.com/X-lab2017/open-digger) [![Node.js CI](https://github.com/X-lab2017/open-digger/actions/workflows/node_ci.yml/badge.svg?branch=master)](https://github.com/X-lab2017/open-digger/actions/workflows/node_ci.yml)
+
+🌍 **语言**: [English](./README.md) | 中文
+
+---
+
+OpenDigger 是一个由 [X-lab](https://x-lab.info) 发起的 **开源数据分析平台**，旨在汇聚全球开发者的智慧，共同对开源相关数据进行分析和洞察，帮助大家更好地理解和参与开源。
+
+### 文档
+
+请访问 [官方网站](https://open-digger.cn/) 获取更多关于 OpenDigger 的使用文档。
+
+### 交流
+
+欢迎扫码添加我的个人微信，我会邀请你进入我们的讨论群。
+
+<div align=center>
+<img src='./docs/assets/wechat-qrcode.png' width="250px">
+</div>
+
+### 许可证
+
+本项目代码部分使用 [Apache-2.0 开源许可证](LICENSE)，使用时请确保遵守相关协议。

--- a/README.md
+++ b/README.md
@@ -2,11 +2,15 @@
 
 [![apache2](https://img.shields.io/badge/license-Apache%202-blue)](LICENSE) [![](https://img.shields.io/badge/Data-OpenDigger-2097FF)](https://github.com/X-lab2017/open-digger) [![Node.js CI](https://github.com/X-lab2017/open-digger/actions/workflows/node_ci.yml/badge.svg?branch=master)](https://github.com/X-lab2017/open-digger/actions/workflows/node_ci.yml)
 
+🌍 **Language**: English | [中文](./README-zh.md)
+
+---
+
 OpenDigger is an open source analysis platform for all open source data initiated by [X-lab](https://x-lab.info), this project aims to combine the wisdom of global developers to jointly analyze and insight into open source related data to help everyone better understand and participate in open source.
 
 ## Documentation
 
-Please visit the [official website](https://open-digger.cn/) to find more documentation about OpenDigger.
+Please visit the [official website](https://open-digger.cn/en/) to find more documentation about OpenDigger.
 
 ## Communication
 


### PR DESCRIPTION
During the process of submitting my OpenDigger paper, one of the reviewers suggested that the documentation linked in the English README should point to the English documentation (instead of the current Chinese page). Therefore, I made the modification and also added a Chinese version of the documentation, making it easier for more people to read.