### PR TITLE
label: Update data for Database technical area labled on dbdb.io and DB-Engines Ranking up to September 30, 2025.

### DIFF
--- a/labeled_data/technology/database/relational.yml
+++ b/labeled_data/technology/database/relational.yml
@@ -67,6 +67,8 @@ data:
           name: Remi-Coulom/joedb
         - id: 574694308
           name: RhizomeDB/rs-rhizome
+        - id: 685897222
+          name: Shannon-Data/ShannonBase
         - id: 42580991
           name: SnappyDataInc/snappydata
         - id: 402945349
@@ -247,6 +249,8 @@ data:
           name: kelindar/column
         - id: 199466858
           name: kkuchta/tabdb
+        - id: 591417438
+          name: launix-de/memcp
         - id: 7502247
           name: lealone/Lealone
         - id: 543276238

--- a/labeled_data/technology/database/vector.yml
+++ b/labeled_data/technology/database/vector.yml
@@ -9,6 +9,10 @@ data:
           name: DeployQL/LintDB
         - id: 893031915
           name: HelixDB/helix-db
+        - id: 1041584089
+          name: RijinRaju/octanedb
+        - id: 685897222
+          name: Shannon-Data/ShannonBase
         - id: 201403923
           name: activeloopai/deeplake
         - id: 124315604


### PR DESCRIPTION
Fix https://github.com/X-lab2017/open-digger/issues/1721

Batch label data: Incrementally add labeled repositories into the database technology.
Update Data: 
  - Update labeled data of Opensource DBMS with a github repo link based on dbdb.io and DB-Engines up to September 30, 2025. 

**Filter conditions**: 
- Collected by dbdb.io on September 30, 2025 OR Rankings in the DB-Engines Rankings table on September 30, 2025; 
- Has open source license; 
- Has repository link on GitHub; 
- The increment relative to the version https://github.com/X-lab2017/open-digger/issues/1709 on July 31, 2025 or August 31, 2025(nothing changed to the data in August, see the https://github.com/X-lab2017/open-digger/pull/1710#issuecomment-3259022772).

Features:
- Add 3 new repositories with labels in ["Relational", "Vector"].

Notes:
- The repo_id is queried from `repository_url` api `https://api.github.com/repos/{owner}/{repo}`.
