### PR TITLE
feat: add label option which uses label data in database in sql

### DIFF
--- a/src/metrics/chaoss.ts
+++ b/src/metrics/chaoss.ts
@@ -4,6 +4,7 @@ import {
   getGroupArrayInsertAtClause, getGroupTimeClause, getGroupIdClause,
   getInnerOrderAndLimit, getOutterOrderAndLimit,
   QueryConfig, TimeDurationOption, timeDurationConstants, processQueryResult, getTopLevelPlatform, getInnerGroupBy,
+  getWithClause,
 } from "./basic";
 import * as clickhouse from '../db/clickhouse';
 import { basicActivitySqlComponent } from "./indices";
@@ -17,6 +18,7 @@ export const chaossTechnicalFork = async (config: QueryConfig) => {
   whereClauses.push(getTimeRangeWhereClause(config));
 
   const sql = `
+${getWithClause(config)}
 SELECT
   id,
   ${getTopLevelPlatform(config)},
@@ -53,6 +55,7 @@ export const chaossCodeChangeCommits = async (config: QueryConfig<CodeChangeComm
   whereClauses.push(getTimeRangeWhereClause(config));
 
   const sql = `
+${getWithClause(config)}
 SELECT
   id,
   ${getTopLevelPlatform(config)},
@@ -88,6 +91,7 @@ export const chaossCodeChangeLines = async (config: QueryConfig<CodeChangeLinesO
   whereClauses.push(getTimeRangeWhereClause(config));
 
   const sql = `
+${getWithClause(config)}
 SELECT
   id,
   ${getTopLevelPlatform(config)},
@@ -133,6 +137,7 @@ export const chaossIssuesNew = async (config: QueryConfig) => {
   whereClauses.push(getTimeRangeWhereClause(config));
 
   const sql = `
+${getWithClause(config)}
 SELECT
   id,
   ${getTopLevelPlatform(config)},
@@ -167,6 +172,7 @@ export const chaossIssuesAndChangeRequestActive = async (config: QueryConfig) =>
   whereClauses.push(getTimeRangeWhereClause(config));
 
   const sql = `
+${getWithClause(config)}
 SELECT
   id,
   ${getTopLevelPlatform(config)},
@@ -198,6 +204,7 @@ export const chaossIssuesClosed = async (config: QueryConfig) => {
   whereClauses.push(getTimeRangeWhereClause(config));
 
   const sql = `
+${getWithClause(config)}
 SELECT
   id,
   ${getTopLevelPlatform(config)},
@@ -244,6 +251,7 @@ const chaossResolutionDuration = async (config: QueryConfig<ResolutionDurationOp
   const sortBy = filterEnumType(config.options?.sortBy, timeDurationConstants.sortByArray, 'avg');
 
   const sql = `
+${getWithClause(config)}
 SELECT
   id,
   ${getTopLevelPlatform(config)},
@@ -308,6 +316,7 @@ const chaossResponseTime = async (config: QueryConfig<TimeDurationOption>, type:
   const sortBy = filterEnumType(config.options?.sortBy, timeDurationConstants.sortByArray, 'avg');
 
   const sql = `
+${getWithClause(config)}
 SELECT
   id,
   ${getTopLevelPlatform(config)},
@@ -374,6 +383,7 @@ export const chaossAge = async (config: QueryConfig<TimeDurationOption>, type: '
   const sortBy = filterEnumType(config.options?.sortBy, timeDurationConstants.sortByArray, 'avg');
 
   const sql = `
+${getWithClause(config)}
 SELECT
   id,
   ${getTopLevelPlatform(config)},
@@ -436,6 +446,7 @@ export const chaossChangeRequestsAccepted = async (config: QueryConfig) => {
   whereClauses.push(getTimeRangeWhereClause(config));
 
   const sql = `
+${getWithClause(config)}
 SELECT
   id,
   ${getTopLevelPlatform(config)},
@@ -470,6 +481,7 @@ export const chaossChangeRequestsDeclined = async (config: QueryConfig) => {
   whereClauses.push(getTimeRangeWhereClause(config));
 
   const sql = `
+${getWithClause(config)}
 SELECT
   id,
   ${getTopLevelPlatform(config)},
@@ -516,6 +528,7 @@ export const chaossChangeRequestsDuration = async (config: QueryConfig<ChangeReq
   const sortBy = filterEnumType(config.options?.sortBy, timeDurationConstants.sortByArray, 'avg');
 
   const sql = `
+${getWithClause(config)}
 SELECT
   id,
   ${getTopLevelPlatform(config)},
@@ -568,6 +581,7 @@ export const chaossChangeRequestsAcceptanceRatio = async (config: QueryConfig) =
   if (repoWhereClause) whereClauses.push(repoWhereClause);
   whereClauses.push(getTimeRangeWhereClause(config));
   const sql = `
+${getWithClause(config)}
 SELECT
   id,
   ${getTopLevelPlatform(config)},
@@ -606,6 +620,7 @@ export const chaossChangeRequests = async (config: QueryConfig) => {
   whereClauses.push(getTimeRangeWhereClause(config));
 
   const sql = `
+${getWithClause(config)}
 SELECT
   id,
   ${getTopLevelPlatform(config)},
@@ -637,6 +652,7 @@ export const chaossChangeRequestReviews = async (config: QueryConfig) => {
   whereClauses.push(getTimeRangeWhereClause(config));
 
   const sql = `
+${getWithClause(config)}
 SELECT
   id,
   ${getTopLevelPlatform(config)},
@@ -685,6 +701,7 @@ export const chaossBusFactor = async (config: QueryConfig<BusFactorOptions>) => 
   whereClauses.push(getTimeRangeWhereClause(config));
 
   const sql = `
+${getWithClause(config)}
 SELECT
   id,
   ${getTopLevelPlatform(config)},
@@ -758,6 +775,7 @@ export const chaossNewContributors = async (config: QueryConfig<NewContributorsO
   const repoWhereClause = await getRepoWhereClause(config);
   if (repoWhereClause) whereClauses.push(repoWhereClause);
   const sql = `
+${getWithClause(config)}
   SELECT
     id,
     ${getTopLevelPlatform(config)},
@@ -840,6 +858,7 @@ export const chaossContributors = async (config: QueryConfig) => {
   whereClauses.push(getTimeRangeWhereClause(config));
 
   const sql = `
+${getWithClause(config)}
 SELECT
   id,
   ${getTopLevelPlatform(config)},
@@ -897,6 +916,7 @@ export const chaossInactiveContributors = async (config: QueryConfig<InactiveCon
   whereClauses.push(`created_at < ${endTimeClause}`);
 
   const sql = `
+${getWithClause(config)}
 SELECT
   id,
   ${getTopLevelPlatform(config)},
@@ -971,6 +991,7 @@ export const chaossActiveDatesAndTimes = async (config: QueryConfig<ActiveDatesA
   }
 
   const sql = `
+${getWithClause(config)}
 SELECT
   id,
   ${getTopLevelPlatform(config)},

--- a/src/metrics/indices.ts
+++ b/src/metrics/indices.ts
@@ -11,7 +11,8 @@ import {
   getOutterOrderAndLimit,
   processQueryResult,
   getTopLevelPlatform,
-  getInnerGroupBy
+  getInnerGroupBy,
+  getWithClause
 } from './basic';
 import * as clickhouse from '../db/clickhouse';
 import { getPlatformData } from '../labelDataUtils';
@@ -32,6 +33,7 @@ export const getRepoOpenrank = async (config: QueryConfig) => {
   whereClause.push("type='Repo' AND legacy=0");
 
   const sql = `
+${getWithClause(config)}
 SELECT
   id,
   ${getTopLevelPlatform(config)},
@@ -64,6 +66,7 @@ export const getUserOpenrank = async (config: QueryConfig) => {
   whereClause.push("type='User' AND legacy=0");
 
   const sql = `
+${getWithClause(config)}
 SELECT
   id,
   ${getTopLevelPlatform(config)},
@@ -108,6 +111,7 @@ export const getRepoCommunityOpenrank = async (config: QueryConfig<RepoCommunity
   }
 
   const sql = `
+${getWithClause(config)}
 SELECT
   id,
   ${getTopLevelPlatform(config, true)},
@@ -198,6 +202,7 @@ export const getUserCommunityOpenrank = async (config: QueryConfig<UserCommunity
   }
 
   const sql = `
+${getWithClause(config)}
 SELECT
   id,
   ${getTopLevelPlatform(config)},
@@ -285,6 +290,7 @@ export const getRepoActivity = async (config: QueryConfig<RepoActivityOption>) =
   const developerDetail = config.options?.developerDetail;
 
   const sql = `
+${getWithClause(config)}
 SELECT
   id,
   ${getTopLevelPlatform(config)},
@@ -346,6 +352,7 @@ export const getUserActivity = async (config: QueryConfig<UserActivityOption>, w
   const repoDetail = config.options?.repoDetail;
 
   const sql = `
+${getWithClause(config)}
 SELECT
   id,
   ${getTopLevelPlatform(config)},
@@ -401,6 +408,7 @@ export const getAttention = async (config: QueryConfig) => {
   whereClauses.push(getTimeRangeWhereClause(config));
 
   const sql = `
+${getWithClause(config)}
 SELECT
   id,
   ${getTopLevelPlatform(config)},

--- a/src/metrics/metrics.ts
+++ b/src/metrics/metrics.ts
@@ -11,7 +11,8 @@ import {
   QueryConfig,
   processQueryResult,
   getTopLevelPlatform,
-  getInnerGroupBy
+  getInnerGroupBy,
+  getWithClause
 } from "./basic";
 import * as clickhouse from '../db/clickhouse';
 
@@ -23,6 +24,7 @@ export const repoStars = async (config: QueryConfig) => {
   whereClauses.push(getTimeRangeWhereClause(config));
 
   const sql = `
+${getWithClause(config)}
 SELECT
   id,
   ${getTopLevelPlatform(config)},
@@ -54,6 +56,7 @@ export const repoIssueComments = async (config: QueryConfig) => {
   whereClauses.push(getTimeRangeWhereClause(config));
 
   const sql = `
+${getWithClause(config)}
 SELECT
   id,
   ${getTopLevelPlatform(config)},
@@ -85,6 +88,7 @@ export const repoCount = async (config: QueryConfig) => {
   whereClauses.push(getTimeRangeWhereClause(config));
 
   const sql = `
+${getWithClause(config)}
 SELECT
   id,
   ${getTopLevelPlatform(config)},
@@ -116,6 +120,7 @@ export const repoParticipants = async (config: QueryConfig) => {
   whereClauses.push(getTimeRangeWhereClause(config));
 
   const sql = `
+${getWithClause(config)}
 SELECT
   id,
   ${getTopLevelPlatform(config)},
@@ -162,6 +167,7 @@ export const userEquivalentTimeZone = async (config: QueryConfig<EquivalentTimeZ
    * The procedure will return `13` which is an invalid result for time period without data
    */
   const sql = `
+${getWithClause(config)}
 SELECT
   id,
   ${getTopLevelPlatform(config)},
@@ -205,6 +211,7 @@ export const contributorEmailSuffixes = async (config: QueryConfig) => {
   whereClauses.push(getTimeRangeWhereClause(config));
 
   const sql = `
+${getWithClause(config)}
 SELECT
   id,
   ${getTopLevelPlatform(config)},


### PR DESCRIPTION
This PR adds label to queryConfig option, which uses label data in database for metric querying.

But group by label type still uses label data in file and directly injected into SQL.

The labelUnion and labelIntersect option still remain in the options to make sure old method still works.