### PR TITLE
label: Update data for Database technical area labeled on dbdb.io and DB-Engines Ranking up to October 31, 2025.

### DIFF
--- a/labeled_data/technology/database/key_value.yml
+++ b/labeled_data/technology/database/key_value.yml
@@ -363,6 +363,8 @@ data:
           name: vinniefalco/NuDB
         - id: 385356389
           name: vmware/splinterdb
+        - id: 879826699
+          name: voidDB/voidDB
         - id: 214605
           name: voldemort/voldemort
         - id: 580788054


### PR DESCRIPTION
Fix https://github.com/X-lab2017/open-digger/issues/1733

Batch label data: Incrementally add labeled repositories into the database technology.
Update Data: 
  - Update labeled data of Opensource DBMS with a github repo link based on dbdb.io and DB-Engines up to October 31, 2025. 

**Filter conditions**: 
- Collected by dbdb.io on October 31, 2025 OR Rankings in the DB-Engines Rankings table on October 31, 2025; 
- Has open source license; 
- Has repository link on GitHub; 
- The increment relative to the version https://github.com/X-lab2017/open-digger/issues/1721 on September 30, 2025.

Features:
- Add 1 new repository with labels in ["Key-value"].

Notes:
- The repo_id is queried from `repository_url` api `https://api.github.com/repos/{owner}/{repo}`.
