### PR TITLE
feat: add normalized community openrank view

### DIFF
--- a/src/scripts/createViews.ts
+++ b/src/scripts/createViews.ts
@@ -1,4 +1,5 @@
 import { query } from "../db/clickhouse";
+import { basicActivitySqlComponent } from "../metrics/indices";
 
 (async () => {
   const createUserView = async () => {
@@ -212,8 +213,75 @@ GROUP BY issue_id, platform
     await query(createViewQuery);
   };
 
+  const createNormalizedCommunityOpenRankView = async () => {
+    // The normalized_community_openrank view is used to store the normalized community openrank info for the all repos
+    // The normalized_community_openrank view is refreshed every 1 day
+    // The normalized_community_openrank is calculated by the community openrank and the global openrank
+    // The normalized_community_openrank uses activity instead of community openrank if it is not calculated
+    await query(`DROP TABLE IF EXISTS normalized_community_openrank`);
+    const createViewQuery = `
+CREATE MATERIALIZED VIEW IF NOT EXISTS normalized_community_openrank
+REFRESH EVERY 1 DAY
+(
+   platform LowCardinality(String),
+   repo_id UInt64,
+   repo_name LowCardinality(String),
+   org_id UInt64,
+   org_login LowCardinality(String),
+   actor_id UInt64,
+   actor_login LowCardinality(String),
+   openrank Float,
+   yyyymm UInt32,
+   created_at DateTime
+)
+ENGINE = MergeTree()
+ORDER BY (repo_id, platform)
+POPULATE
+AS
+SELECT platform, repo_id, repo_name, org_id, org_login, actor_id, actor_login, openrank, yyyymm, created_at FROM
+(
+  SELECT
+    g.platform,
+    g.repo_id,
+    g.repo_name,
+    g.org_id,
+    g.org_login,
+    g.created_at,
+    arrayJoin(arrayMap(x -> tuple(x.1, x.2, g.openrank * x.3 / gor), c.gor_details)) AS openrank_arr,
+    openrank_arr.1 AS actor_id,
+    openrank_arr.2 AS actor_login,
+    openrank_arr.3 AS openrank,
+    toYYYYMM(c.created_at) AS yyyymm
+  FROM
+  (SELECT platform, repo_id, repo_name, org_id, org_login, openrank, created_at
+    FROM global_openrank WHERE type = 'Repo' AND legacy = 0) g
+  INNER JOIN
+  ((SELECT repo_id, platform, SUM(openrank) AS gor, groupArray(tuple(actor_id, actor_login, openrank)) AS gor_details, created_at
+    FROM community_openrank WHERE actor_id > 0 AND actor_login NOT LIKE '%[bot]' AND
+    (platform, actor_id) NOT IN (SELECT platform, entity_id FROM flatten_labels WHERE id = ':bot' AND entity_type = 'User')
+    GROUP BY repo_id, platform, created_at)
+    UNION ALL
+    (SELECT repo_id, platform, SUM(activity) AS gor, groupArray(tuple(actor_id, actor_login, activity)) AS gor_details, m AS created_at
+    FROM (
+      SELECT repo_id, platform, ${basicActivitySqlComponent}, toStartOfMonth(created_at) AS m
+      FROM events WHERE
+      (platform, actor_id) NOT IN (SELECT platform, entity_id FROM flatten_labels WHERE id = ':bot' AND entity_type = 'User')
+      AND type IN ('IssuesEvent', 'IssueCommentEvent', 'PullRequestEvent', 'PullRequestReviewCommentEvent')
+      AND (repo_id, platform) NOT IN (SELECT id, platform FROM export_repo)
+      GROUP BY repo_id, platform, actor_id, m
+      HAVING actor_login NOT LIKE '%[bot]'
+    )
+    GROUP BY repo_id, platform, created_at)
+  ) c
+  ON g.repo_id = c.repo_id AND g.created_at = c.created_at AND g.platform = c.platform
+)
+`;
+    await query(createViewQuery);
+  };
+
   await createUserView();
   await createNameView();
   await createFlattenLabelView();
   await createPullsWitLabelView();
+  await createNormalizedCommunityOpenRankView();
 })();


### PR DESCRIPTION
Add a new view called `normalized_community_openrank` which used global OpenRank and community OpenRank to calculate the normalized OpenRank for export repos and global OpenRank and activity to calculate for others.