### PR TITLE
label: Update data for Database technical area labeled on dbdb.io and DB-Engines Ranking up to December 31, 2025.

### DIFF
--- a/labeled_data/technology/database/graph.yml
+++ b/labeled_data/technology/database/graph.yml
@@ -17,6 +17,8 @@ data:
           name: DevrexLabs/OrigoDB
         - id: 893031915
           name: HelixDB/helix-db
+        - id: 1071734040
+          name: LadybugDB/ladybug
         - id: 92834468
           name: Pometry/Raphtory
         - id: 45098765
@@ -79,6 +81,8 @@ data:
           name: microsoft/GraphEngine
         - id: 7083240
           name: orientechnologies/orientdb
+        - id: 1075506724
+          name: orneryd/Mimir
         - id: 26917250
           name: pkumod/gStore
         - id: 166387176

--- a/labeled_data/technology/database/relational.yml
+++ b/labeled_data/technology/database/relational.yml
@@ -74,6 +74,8 @@ data:
           name: OpenTenBase/OpenTenBase
         - id: 41443810
           name: Postgres-XL/Postgres-XL
+        - id: 605546193
+          name: RayforceDB/rayforce
         - id: 74375185
           name: RedBeardLab/rediSQL
         - id: 30113463


### PR DESCRIPTION
Fix https://github.com/X-lab2017/open-digger/issues/1756

Batch label data: Incrementally add labeled repositories into the database technology.
Update Data: 
  - Update labeled data of Opensource DBMS with a github repo link based on dbdb.io and DB-Engines up to December 31, 2025. 

**Filter conditions**: 
- Collected by dbdb.io on December 31, 2025 OR Rankings in the DB-Engines Rankings table on December 31, 2025; 
- Has open source license; 
- Has repository link on GitHub; 
- The increment relative to the version https://github.com/X-lab2017/open-digger/issues/1733 on October 31, 2025 or November 30, 2025(nothing changed to the data in August, see the https://github.com/X-lab2017/open-digger/pull/1734#issuecomment-3592854769).

Features:
- ~~**Recover database labels deleted in @46cdc7a ~ @0b172db .**~~ (Need to be reviewed @frank-zsy; Change revoked after review.)
  - Retains the company labels and foundation labels.
  - Recover reason: I couldn't find the technology labels information of the repos removed in these versions.
  - Review opinion: Revoke the “Recover” part.
  - Revoke reason: The label information is transmitted through project level labels(see the [case](https://github.com/X-lab2017/open-digger/pull/1757#issuecomment-3707928760)).
- Add 3 new repositories with labels in ["Graph", "Relational"].
  - Add Graph Repos: ['LadybugDB/ladybug', 'orneryd/Mimir']; 
  - Add a Relational Repo: ['RayforceDB/rayforce'].

Notes:
- The repo_id is queried from `repository_url` api `https://api.github.com/repos/{owner}/{repo}`.

