### PR TITLE
fix: fix base table error after table merge

### DIFF
--- a/src/cron/tasks/globalOpenrank.ts
+++ b/src/cron/tasks/globalOpenrank.ts
@@ -105,12 +105,12 @@ const task: Task = {
             argMax(org_login, created_at) AS org_login,
             actor_id,
             argMax(actor_login, created_at) AS actor_login,
-            ROUND(uniqIf(issue_id, type='IssuesEvent' AND action='opened') * 22.235 +
-              uniqIf(issue_comment_id, type='IssueCommentEvent') * 5.252 +
-              uniqIf(issue_id, type='IssuesEvent' AND action='closed') * 9.712 + 
-              uniqIf(pull_review_comment_id, type='PullRequestReviewCommentEvent') * 7.427 + 
-              uniqIf(issue_id, type='PullRequestEvent' AND action='opened') * 40.679 + 
-              uniqIf(push_id, type='PushEvent') * 14.695, 3) AS activity,
+            ROUND(uniqExactIf(issue_id, type='IssuesEvent' AND action='opened') * 22.235 +
+              uniqExactIf(issue_comment_id, type='IssueCommentEvent') * 5.252 +
+              uniqExactIf(issue_id, type='IssuesEvent' AND action='closed') * 9.712 + 
+              uniqExactIf(pull_review_comment_id, type='PullRequestReviewCommentEvent') * 7.427 + 
+              uniqExactIf(issue_id, type='PullRequestEvent' AND action='opened') * 40.679 + 
+              uniqExactIf(push_id, type='PushEvent') * 14.695, 3) AS activity,
             MAX(created_at) AS max_created_at,
             countIf((type, action) IN (('IssuesEvent', 'opened'), ('IssueCommentEvent', 'created'),
             ('IssuesEvent', 'closed'), ('PullRequestReviewCommentEvent', 'created'),

--- a/src/metrics/basic.ts
+++ b/src/metrics/basic.ts
@@ -377,16 +377,3 @@ export const processQueryResult = (result: any, customKeys: string[],
     return obj;
   });
 };
-
-export const githubAppBaseTable = (whereClause: string) => {
-  return `
-  (
-    (SELECT platform, repo_id, repo_name, org_id, org_login, actor_id, actor_login, toString(type) AS type, action, issue_number, issue_id, issue_author_id, issue_author_login, issue_comment_id, pull_review_comment_id, pull_merged, issue_title, body, created_at
-      FROM github_app_repo_data
-      WHERE ${whereClause})
-    UNION ALL
-    (SELECT toString(platform) AS platform, repo_id, repo_name, org_id, org_login, actor_id, actor_login, toString(type) AS type, toString(action) AS action, issue_number, issue_id, issue_author_id, issue_author_login, issue_comment_id, pull_review_comment_id, pull_merged, issue_title, body, created_at
-      FROM events
-      WHERE ${whereClause} AND (platform, repo_id) NOT IN (SELECT platform, repo_id FROM github_app_repo_data)) 
-  )`;
-};

--- a/src/metrics/chaoss.ts
+++ b/src/metrics/chaoss.ts
@@ -4,7 +4,7 @@ import {
   getGroupArrayInsertAtClause, getGroupTimeClause, getGroupIdClause,
   getInnerOrderAndLimit, getOutterOrderAndLimit,
   QueryConfig, TimeDurationOption, timeDurationConstants, processQueryResult, getTopLevelPlatform, getInnerGroupBy,
-  getWithClause, githubAppBaseTable,
+  getWithClause,
 } from "./basic";
 import * as clickhouse from '../db/clickhouse';
 import { basicActivitySqlComponent } from "./indices";
@@ -150,7 +150,8 @@ FROM
     ${getGroupTimeClause(config)},
     ${getGroupIdClause(config)},
     COUNT(DISTINCT issue_id) AS count
-  FROM ${githubAppBaseTable(whereClauses.join(' AND '))}
+  FROM events
+  WHERE ${whereClauses.join(' AND ')}
   GROUP BY id, platform, time
   ${getInnerOrderAndLimit(config, 'count')}
 )
@@ -183,7 +184,8 @@ FROM
     ${getGroupTimeClause(config)},
     ${getGroupIdClause(config)},
     COUNT(DISTINCT issue_id) AS count
-  FROM ${githubAppBaseTable(whereClauses.join(' AND '))}
+  FROM events
+  WHERE ${whereClauses.join(' AND ')}
   GROUP BY id, platform, time
   ${getInnerOrderAndLimit(config, 'count')}
 )
@@ -215,7 +217,7 @@ FROM
     ${getGroupTimeClause(config)},
     ${getGroupIdClause(config)},
     COUNT(DISTINCT issue_id) AS count
-  FROM ${githubAppBaseTable(whereClauses.join(' AND '))}
+  FROM events
   WHERE ${whereClauses.join(' AND ')}
   GROUP BY id, platform, time
   ${getInnerOrderAndLimit(config, 'count')}
@@ -387,7 +389,7 @@ SELECT
   ${getTopLevelPlatform(config)},
   argMax(name, time),
   ${getGroupArrayInsertAtClause(config, { key: `avg`, defaultValue: 'NaN', positionByEndTime: true })},
-  ${getGroupArrayInsertAtClause(config, { key: 'levels', value: 'if(arrayAll(x -> x = 0, age_levels), [], age_levels)', defaultValue: `[]`, noPrecision: true, positionByEndTime: true })},
+  ${getGroupArrayInsertAtClause(config, { key: 'levels', value: 'if(arrayAll(x -> x = 0, age_levels), [], age_levels)', defaultValue: `[0,0,0,0]`, noPrecision: true, positionByEndTime: true })},
   ${timeDurationConstants.quantileArray.map(q => getGroupArrayInsertAtClause(config, { key: `quantile_${q}`, defaultValue: 'NaN', positionByEndTime: true })).join(',')}
 FROM
 (
@@ -457,7 +459,8 @@ FROM
     ${getGroupTimeClause(config)},
     ${getGroupIdClause(config)},
     COUNT(DISTINCT issue_id) AS count
-  FROM ${githubAppBaseTable(whereClauses.join(' AND '))}
+  FROM events
+  WHERE ${whereClauses.join(' AND ')}
   ${getInnerGroupBy(config)}
   ${getInnerOrderAndLimit(config, 'count')}
 )
@@ -629,7 +632,8 @@ FROM
     ${getGroupTimeClause(config)},
     ${getGroupIdClause(config)},
     COUNT(DISTINCT issue_id) AS count
-  FROM ${githubAppBaseTable(whereClauses.join(' AND '))}
+  FROM events
+  WHERE ${whereClauses.join(' AND ')}
   ${getInnerGroupBy(config)}
   ${getInnerOrderAndLimit(config, 'count')}
 )
@@ -660,7 +664,8 @@ FROM
     ${getGroupTimeClause(config)},
     ${getGroupIdClause(config)},
     COUNT(DISTINCT pull_review_comment_id) AS count
-  FROM ${githubAppBaseTable(whereClauses.join(' AND '))}
+  FROM events
+  WHERE ${whereClauses.join(' AND ')}
   ${getInnerGroupBy(config)}
   ${getInnerOrderAndLimit(config, 'count')}
 )
@@ -828,7 +833,8 @@ ${getWithClause(config)}
       }
     })()},
             created_at
-          FROM ${githubAppBaseTable(whereClauses.join(' AND '))}
+          FROM events
+          WHERE ${whereClauses.join(' AND ')}
           ${(config.options?.withBot && by !== 'commit') ? '' : "HAVING author NOT LIKE '%[bot]'"}
         )
       GROUP BY platform, repo_id, org_id, ${by === 'commit' ? 'author' : 'actor_id'}
@@ -866,7 +872,8 @@ FROM
     ${getGroupIdClause(config)},
     groupArray(DISTINCT(issue_author_login)) AS detail,
     COUNT(DISTINCT issue_author_id) AS count
-  FROM ${githubAppBaseTable(whereClauses.join(' AND '))}
+  FROM events
+  WHERE ${whereClauses.join(' AND ')}
   GROUP BY id, platform, time
   ${getInnerOrderAndLimit(config, 'count')}
 )

--- a/src/metrics/metrics.ts
+++ b/src/metrics/metrics.ts
@@ -12,8 +12,7 @@ import {
   processQueryResult,
   getTopLevelPlatform,
   getInnerGroupBy,
-  getWithClause,
-  githubAppBaseTable
+  getWithClause
 } from "./basic";
 import * as clickhouse from '../db/clickhouse';
 
@@ -133,7 +132,8 @@ FROM
     ${getGroupTimeClause(config)},
     ${getGroupIdClause(config)},
     COUNT(DISTINCT actor_id) AS count
-  FROM ${githubAppBaseTable(whereClauses.join(' AND '))}
+  FROM events
+  WHERE ${whereClauses.join(' AND ')}
   ${getInnerGroupBy(config)}
   ${getInnerOrderAndLimit(config, 'count')}
 )


### PR DESCRIPTION
This PR fixes:

- The `githubAppBaseTable` which is a legacy implementation when events data and GitHub app data are separated into different tables. But now they are all in `events` table, so we should not use this anymore.
- User `uniqExactIf` instead of `uniqIf` to get more accurate data.