### PR TITLE
label: Update data for Database technical area labeled on dbdb.io and DB-Engines Ranking up to January 31, 2026; Recover database labels.

### DIFF
--- a/labeled_data/technology/database/document.yml
+++ b/labeled_data/technology/database/document.yml
@@ -74,10 +74,18 @@ data:
           name: apache/couchdb
         - id: 5683653
           name: apache/drill
+        - id: 341631350
+          name: apache/lucene
+        - id: 50229487
+          name: apache/lucene-solr
+        - id: 114187903
+          name: apple/foundationdb
         - id: 137869753
           name: appy-one/acebase
         - id: 2649214
           name: arangodb/arangodb
+        - id: 1085719788
+          name: ashfromsky/yaradb
         - id: 36778364
           name: attic-labs/noms
         - id: 642912355
@@ -100,10 +108,14 @@ data:
           name: capjamesg/jamesql
         - id: 639434928
           name: cfu288/SylvieJS
+        - id: 546206616
+          name: chroma-core/chroma
         - id: 13353426
           name: cinchapi/concourse
         - id: 66783145
           name: couchbase/couchbase-lite-core
+        - id: 9342529
+          name: crate/crate
         - id: 722117815
           name: cursusdb/cursusdb
         - id: 249981301
@@ -118,6 +130,8 @@ data:
           name: eXist-db/exist
         - id: 266444815
           name: earthstar-project/earthstar
+        - id: 507775
+          name: elastic/elasticsearch
         - id: 411979983
           name: elmarti/camadb
         - id: 587246478
@@ -136,6 +150,8 @@ data:
           name: goshops-com/StormiDB
         - id: 285669400
           name: graphikDB/graphik
+        - id: 957143813
+          name: hash-anu/AnuDB
         - id: 12050336
           name: hhblaze/DBreeze
         - id: 50836580
@@ -160,6 +176,12 @@ data:
           name: kagisearch/vectordb
         - id: 1776883
           name: kimchy/compass
+        - id: 622856821
+          name: kronotop/kronotop
+        - id: 607441698
+          name: lancedb/lancedb
+        - id: 349172057
+          name: linkedin/venice
         - id: 376679845
           name: losfair/RefineDB
         - id: 9795883
@@ -206,6 +228,8 @@ data:
           name: polypheny/Polypheny-DB
         - id: 714074
           name: pouchdb/pouchdb
+        - id: 5349565
+          name: prestodb/presto
         - id: 10153163
           name: priitj/whitedb
         - id: 75425073
@@ -220,6 +244,8 @@ data:
           name: radare/sdb
         - id: 129436009
           name: rakibtg/SleekDB
+        - id: 542714
+          name: ravendb/ravendb
         - id: 1917262
           name: realm/realm-core
         - id: 223462217
@@ -242,8 +268,12 @@ data:
           name: small-tech/jsdb
         - id: 192631273
           name: sourcenetwork/defradb
+        - id: 436658287
+          name: surrealdb/surrealdb
         - id: 22761491
           name: symisc/unqlite
+        - id: 911980
+          name: tarantool/tarantool
         - id: 3920536
           name: teamdev/densodb
         - id: 11654790
@@ -268,11 +298,15 @@ data:
           name: vearch/vearch
         - id: 634656527
           name: vector5ai/vector5db
+        - id: 60377070
+          name: vespa-engine/vespa
         - id: 735981
           name: xapian/xapian
         - id: 125824259
           name: xtdb/xtdb
         - id: 456549280
           name: ydb-platform/ydb
+        - id: 574588439
+          name: ytsaurus/ytsaurus
         - id: 47479424
           name: zerodb/zerodb

--- a/labeled_data/technology/database/graph.yml
+++ b/labeled_data/technology/database/graph.yml
@@ -18,6 +18,8 @@ data:
           name: DevrexLabs/OrigoDB
         - id: 893031915
           name: HelixDB/helix-db
+        - id: 77385607
+          name: JanusGraph/janusgraph
         - id: 1071734040
           name: LadybugDB/ladybug
         - id: 92834468
@@ -26,6 +28,8 @@ data:
           name: PureSolTechnologies/DuctileDB
         - id: 84458512
           name: RedisGraph/RedisGraph
+        - id: 1040715058
+          name: Relatude/Relatude.DB
         - id: 43494700
           name: SparsityTechnologies/sparksee-server
         - id: 528766495
@@ -80,10 +84,12 @@ data:
           name: memgraph/memgraph
         - id: 81411018
           name: microsoft/GraphEngine
+        - id: 6650539
+          name: neo4j/neo4j
         - id: 7083240
           name: orientechnologies/orientdb
-        - id: 1075506724
-          name: orneryd/Mimir
+        - id: 1111263109
+          name: orneryd/NornicDB
         - id: 26917250
           name: pkumod/gStore
         - id: 166387176
@@ -94,12 +100,16 @@ data:
           name: ragedb/ragedb
         - id: 73235061
           name: rayokota/hgraphdb
+        - id: 1051002990
+          name: sanonone/kektordb
         - id: 743502
           name: sones/sones
         - id: 55578752
           name: stellardb/StellarDB
         - id: 238509
           name: stevedekorte/vertexdb
+        - id: 436658287
+          name: surrealdb/surrealdb
         - id: 198466472
           name: terminusdb/terminusdb
         - id: 3548254

--- a/labeled_data/technology/database/key_value.yml
+++ b/labeled_data/technology/database/key_value.yml
@@ -82,16 +82,24 @@ data:
           name: Treode/store
         - id: 180245584
           name: YosiSF/EinsteinDB
+        - id: 96138741
+          name: YottaDB/YDB
         - id: 124315604
           name: aerospike/aerospike-server
         - id: 116522453
           name: akrylysov/pogreb
         - id: 161674141
           name: alash3al/redix
+        - id: 206424
+          name: apache/cassandra
         - id: 34839383
           name: apache/geode
+        - id: 31006158
+          name: apache/ignite
         - id: 28738447
           name: apache/kylin
+        - id: 114187903
+          name: apple/foundationdb
         - id: 2649214
           name: arangodb/arangodb
         - id: 266515876
@@ -150,6 +158,8 @@ data:
           name: dicedb/dice
         - id: 789424265
           name: dmarro89/dare-db
+        - id: 437245741
+          name: dragonflydb/dragonfly
         - id: 17224514
           name: ehcache/ehcache3
         - id: 393005910
@@ -158,10 +168,18 @@ data:
           name: erthink/libmdbx
         - id: 278320002
           name: estraier/tkrzw
+        - id: 94593596
+          name: etcd-io/bbolt
+        - id: 11225014
+          name: etcd-io/etcd
+        - id: 6934395
+          name: facebook/rocksdb
         - id: 70541093
           name: facebookarchive/beringei
         - id: 74678263
           name: fanjinfei/grapheekdb
+        - id: 841059560
+          name: feichai0017/NoKV
         - id: 606800919
           name: firstbatchxyz/hollowdb
         - id: 292049131
@@ -220,6 +238,8 @@ data:
           name: linkedin/PalDB
         - id: 323389945
           name: logicalclocks/rondb
+        - id: 1066389431
+          name: mailmug/zentropy
         - id: 62980788
           name: marceloboeira/bojack
         - id: 30123805
@@ -268,10 +288,16 @@ data:
           name: pilgr/Paper
         - id: 41986369
           name: pingcap/tidb
+        - id: 5349565
+          name: prestodb/presto
         - id: 385283362
           name: prologic/bitcask
         - id: 6838921
           name: prometheus/prometheus
+        - id: 542714
+          name: ravendb/ravendb
+        - id: 156018
+          name: redis/redis
         - id: 441299511
           name: reductstore/reductstore
         - id: 210997817
@@ -302,6 +328,8 @@ data:
           name: scalaris-team/scalaris
         - id: 715589
           name: scalien/scaliendb
+        - id: 28449431
+          name: scylladb/scylla
         - id: 1499938
           name: shino/kai
         - id: 121126549
@@ -328,6 +356,8 @@ data:
           name: surrealdb/echodb
         - id: 22761491
           name: symisc/unqlite
+        - id: 911980
+          name: tarantool/tarantool
         - id: 63731386
           name: tidwall/buntdb
         - id: 64404140
@@ -348,6 +378,8 @@ data:
           name: topling/toplingdb
         - id: 223895357
           name: tuxmonk/pupdb
+        - id: 775743011
+          name: valkey-io/valkey
         - id: 179588377
           name: vinniefalco/NuDB
         - id: 385356389
@@ -360,6 +392,8 @@ data:
           name: web3-storage/pail
         - id: 30828379
           name: willemt/pearldb
+        - id: 2944302
+          name: wiredtiger/wiredtiger
         - id: 65259211
           name: xap/xap
         - id: 20433978

--- a/labeled_data/technology/database/object_oriented.yml
+++ b/labeled_data/technology/database/object_oriented.yml
@@ -15,6 +15,8 @@ data:
           name: Alachisoft/TayzGrid
         - id: 681142
           name: Bobris/BTDB
+        - id: 52080367
+          name: CUBRID/cubrid
         - id: 329729926
           name: CondensationDB/Condensation-java
         - id: 8799170
@@ -23,6 +25,8 @@ data:
           name: HydrasDB/hydra
         - id: 1244027
           name: ModeShape/modeshape
+        - id: 1040715058
+          name: Relatude/Relatude.DB
         - id: 150752008
           name: SapphireDb/SapphireDb
         - id: 43494700
@@ -77,6 +81,8 @@ data:
           name: mateusfreira/nun-db
         - id: 273564373
           name: morecraf/Siaqodb
+        - id: 351806852
+          name: neondatabase/neon
         - id: 79901405
           name: objectbox/objectbox-java
         - id: 7083240

--- a/labeled_data/technology/database/relational.yml
+++ b/labeled_data/technology/database/relational.yml
@@ -39,12 +39,20 @@ data:
           name: BTrDB/btrdb-server
         - id: 581145740
           name: ByConity/ByConity
+        - id: 52080367
+          name: CUBRID/cubrid
+        - id: 60246359
+          name: ClickHouse/ClickHouse
+        - id: 654870350
+          name: ClockworkLabs/SpacetimeDB
         - id: 129072319
           name: CovenantSQL/CovenantSQL
         - id: 151762200
           name: CptTZ/SmallSQL
         - id: 25871447
           name: DaveVoorhis/Rel
+        - id: 1056702615
+          name: DavidLiedle/DriftDB
         - id: 93621710
           name: DeepFound/deep_engine
         - id: 8799170
@@ -53,6 +61,8 @@ data:
           name: Expensify/Bedrock
         - id: 54005538
           name: FirebirdSQL/firebird
+        - id: 1034164151
+          name: Frigatebird-db/frigatebird
         - id: 496817075
           name: GlareDB/glaredb
         - id: 345982729
@@ -67,6 +77,8 @@ data:
           name: JuliaData/JuliaDB.jl
         - id: 533032
           name: LinkedInAttic/sensei
+        - id: 19816070
+          name: MariaDB/server
         - id: 135423959
           name: Mckoi/origsqldb
         - id: 316690542
@@ -101,14 +113,20 @@ data:
           name: amelielabs/amelie
         - id: 3927863
           name: antonmks/Alenka
+        - id: 358917318
+          name: apache/arrow-datafusion
         - id: 1918497
           name: apache/derby
         - id: 99919302
           name: apache/doris
+        - id: 6358188
+          name: apache/druid
         - id: 20587599
           name: apache/flink
         - id: 41952293
           name: apache/hawq
+        - id: 206444
+          name: apache/hive
         - id: 56128733
           name: apache/impala
         - id: 496505424
@@ -123,6 +141,8 @@ data:
           name: apache/kyuubi
         - id: 20473418
           name: apache/phoenix
+        - id: 19961085
+          name: apache/pinot
         - id: 49876476
           name: apache/shardingsphere
         - id: 17165658
@@ -163,6 +183,8 @@ data:
           name: cmu-db/noisepage
         - id: 420965027
           name: cnosdb/cnosdb
+        - id: 16563587
+          name: cockroachdb/cockroach
         - id: 296950535
           name: codemix/ts-sql
         - id: 254418044
@@ -177,6 +199,8 @@ data:
           name: cznic/ql
         - id: 824462634
           name: darshan117/BroDB
+        - id: 302827809
+          name: datafuselabs/databend
         - id: 2894420
           name: deveel/deveeldb
         - id: 52507351
@@ -187,6 +211,8 @@ data:
           name: dreamdbvilas/wonderdb
         - id: 97518356
           name: dremio/dremio-oss
+        - id: 138754790
+          name: duckdb/duckdb
         - id: 341208515
           name: edgelesssys/edgelessdb
         - id: 61373806
@@ -203,6 +229,8 @@ data:
           name: eyalroz/c-store
         - id: 172208960
           name: eztools-software/FileDb
+        - id: 388946490
+          name: facebookincubator/velox
         - id: 40127179
           name: featurebasedb/featurebase
         - id: 392839612
@@ -283,6 +311,8 @@ data:
           name: myscale/MyScaleDB
         - id: 24494032
           name: mysql/mysql-server
+        - id: 351806852
+          name: neondatabase/neon
         - id: 147880351
           name: njaard/sonnerie
         - id: 372536760
@@ -317,10 +347,14 @@ data:
           name: postgres/postgres
         - id: 258454329
           name: ppml38/icecoal
+        - id: 5349565
+          name: prestodb/presto
         - id: 26774602
           name: proullon/ramsql
         - id: 275838748
           name: qikkDB/qikkdb
+        - id: 19257422
+          name: questdb/questdb
         - id: 5665061
           name: radare/sdb
         - id: 117920609
@@ -329,6 +363,8 @@ data:
           name: rayokota/kareldb
         - id: 393235957
           name: risinglightdb/risinglight
+        - id: 453068084
+          name: risingwavelabs/risingwave
         - id: 23247808
           name: rqlite/rqlite
         - id: 101723057
@@ -351,6 +387,8 @@ data:
           name: stewartsmith/drizzle
         - id: 975891605
           name: stoolap/stoolap
+        - id: 436658287
+          name: surrealdb/surrealdb
         - id: 591304097
           name: sutoiku/puffin
         - id: 196353673
@@ -363,6 +401,8 @@ data:
           name: tinyplex/tinybase
         - id: 22868877
           name: traildb/traildb
+        - id: 166515022
+          name: trinodb/trino
         - id: 697976
           name: twitter-archive/snowflake
         - id: 149626591
@@ -377,6 +417,8 @@ data:
           name: yaledb/calvin
         - id: 456549280
           name: ydb-platform/ydb
+        - id: 105944401
+          name: yugabyte/yugabyte-db
         - id: 23452009
           name: yxymit/DBx1000
         - id: 334353425

--- a/labeled_data/technology/database/search_engine.yml
+++ b/labeled_data/technology/database/search_engine.yml
@@ -11,15 +11,23 @@ data:
     - name: GitHub
       type: Code Hosting
       repos:
+        - id: 50229487
+          name: apache/lucene-solr
+        - id: 507775
+          name: elastic/elasticsearch
         - id: 95614931
           name: manticoresoftware/manticoresearch
         - id: 520096046
           name: marqo-ai/marqo
         - id: 130688011
           name: meilisearch/meilisearch
+        - id: 334274271
+          name: opensearch-project/OpenSearch
         - id: 36992044
           name: sphinxsearch/sphinx
         - id: 79317191
           name: typesense/typesense
+        - id: 60377070
+          name: vespa-engine/vespa
         - id: 735981
           name: xapian/xapian

--- a/labeled_data/technology/database/time_series.yml
+++ b/labeled_data/technology/database/time_series.yml
@@ -17,6 +17,8 @@ data:
           name: 4paradigm/OpenMLDB
         - id: 396867188
           name: ArcadeData/arcadedb
+        - id: 480217156
+          name: GreptimeTeam/greptimedb
         - id: 89848289
           name: KxSystems/kdb
         - id: 16189524
@@ -25,6 +27,8 @@ data:
           name: OpenTSDB/opentsdb
         - id: 55093657
           name: SiriDB/siridb-server
+        - id: 150954997
+          name: VictoriaMetrics/VictoriaMetrics
         - id: 158975124
           name: apache/iotdb
         - id: 420965027
@@ -35,6 +39,8 @@ data:
           name: griddb/griddb
         - id: 17705626
           name: hawkular/hawkular-metrics
+        - id: 13124802
+          name: influxdata/influxdb
         - id: 8039659
           name: kairosdb/kairosdb
         - id: 61153677
@@ -47,6 +53,8 @@ data:
           name: openGemini/openGemini
         - id: 6838921
           name: prometheus/prometheus
+        - id: 19257422
+          name: questdb/questdb
         - id: 10081109
           name: rackerlabs/blueflood
         - id: 135549948
@@ -61,3 +69,5 @@ data:
           name: spotify/heroic
         - id: 196353673
           name: taosdata/TDengine
+        - id: 84240850
+          name: timescale/timescaledb

--- a/labeled_data/technology/database/vector.yml
+++ b/labeled_data/technology/database/vector.yml
@@ -26,6 +26,8 @@ data:
           name: awa-ai/awadb
         - id: 793209340
           name: carsonpo/haystackdb
+        - id: 546206616
+          name: chroma-core/chroma
         - id: 304530333
           name: featureform/embeddinghub
         - id: 628503457
@@ -48,6 +50,10 @@ data:
           name: philippgille/chromem-go
         - id: 40127179
           name: pilosa/pilosa
+        - id: 268163609
+          name: qdrant/qdrant
+        - id: 55072677
+          name: semi-technologies/weaviate
         - id: 195619075
           name: vdaas/vald
         - id: 186332888

--- a/labeled_data/technology/database/wide_column.yml
+++ b/labeled_data/technology/database/wide_column.yml
@@ -18,22 +18,36 @@ data:
           name: MonetDB/MonetDB
         - id: 402945349
           name: StarRocks/StarRocks
+        - id: 150954997
+          name: VictoriaMetrics/VictoriaMetrics
         - id: 2524488
           name: apache/accumulo
+        - id: 206424
+          name: apache/cassandra
         - id: 5683653
           name: apache/drill
+        - id: 6358188
+          name: apache/druid
+        - id: 20089857
+          name: apache/hbase
         - id: 36349344
           name: apache/trafodion
         - id: 18129915
           name: baidu/tera
+        - id: 182849188
+          name: delta-io/delta
         - id: 191676087
           name: eleme/lindb
         - id: 1584552
           name: hypertable/hypertable
+        - id: 13124802
+          name: influxdata/influxdb
         - id: 191442206
           name: kashirin-alex/swc-db
         - id: 473235285
           name: polarsignals/frostdb
+        - id: 5349565
+          name: prestodb/presto
         - id: 28449431
           name: scylladb/scylla
         - id: 41209174


### PR DESCRIPTION
Fix https://github.com/X-lab2017/open-digger/issues/1767

Batch label data: Incrementally add labeled repositories into the database technology.
Update Data: 
  - Update labeled data of Opensource DBMS with a github repo link based on dbdb.io and DB-Engines up to January 31, 2026. 

**Filter conditions**: 
- Collected by dbdb.io on January 31, 2026 OR Rankings in the DB-Engines Rankings table on January 31, 2026; 
- Has open source license; 
- Has repository link on GitHub; 
- The increment relative to the version https://github.com/X-lab2017/open-digger/issues/1756 on December 31, 20256.

Features:
- **Recover database labels deleted in @46cdc7a ~ @ed32be5 .** (see [comment](https://github.com/X-lab2017/open-digger/pull/1757#issuecomment-3737887520))
  - Retains the company labels and foundation labels.
  - Recover reason: I couldn't find the technology labels information of the repos removed in these versions.
  - Discussion opinion:  add the repos data back into the labels.
- Add 9 new repositories with labels in ["Document", "Graph", "Key-value", "Object Oriented", "Relational"] and change 1 repo with labels in ["Graph"].
  - Add 3 Document Repos: ['ashfromsky/yaradb', 'hash-anu/AnuDB', 'kronotop/kronotop']; 
  - Add 2 Graph Repos: ['Relatude/Relatude.DB', 'sanonone/kektordb'];
  - Add 2 Key-value Repos: ['feichai0017/NoKV', 'mailmug/zentropy']; 
  - Add 1 Object Oriented Repo: ['Relatude/Relatude.DB']; 
  - Add 2 Relational Repos: ['DavidLiedle/DriftDB', 'Frigatebird-db/frigatebird'].
  - Change 1 Graph repo: {'from': 'orneryd/Mimir', 'to': 'orneryd/NornicDB'}

Notes:
- The repo_id is queried from `repository_url` api `https://api.github.com/repos/{owner}/{repo}`.

