### PR TITLE
fix: fix community openrank indices

### DIFF
--- a/src/dataProduction/ospp.ts
+++ b/src/dataProduction/ospp.ts
@@ -3,7 +3,9 @@ import { getUserCommunityOpenrank } from "../metrics/indices";
 
 const tableName = 'coding_events';
 const analysisData = async (year: number) => {
-  const rawData = await query<any>(`SELECT * FROM ${tableName} WHERE year=${year} AND event='OSPP'`, { format: 'JSONEachRow' });
+  const rawDataMap = new Map<number, any[]>();
+  rawDataMap.set(year, await query<any>(`SELECT * FROM ${tableName} WHERE year=${year} AND event='OSPP'`, { format: 'JSONEachRow' }));
+  rawDataMap.set(year - 1, await query<any>(`SELECT * FROM ${tableName} WHERE year=${year - 1} AND event='OSPP'`, { format: 'JSONEachRow' }));
 
   const overviewRes = await query<any>(`SELECT
     COUNT(),
@@ -11,13 +13,34 @@ const analysisData = async (year: number) => {
     countIf(state='Finished'),
     uniqExactIf(student_univ, state='Finished')
   FROM ${tableName} WHERE year=${year}`);
+  const lastYearOverviewRes = await query<any>(`SELECT
+    COUNT(),
+    countIf(state='Selected' OR state='Finished'),
+    countIf(state='Finished'),
+    uniqExactIf(student_univ, state='Finished')
+  FROM ${tableName} WHERE year=${year - 1}`);
   const [totalCount, selectedCount, finishedCount, univCount] = overviewRes[0];
+  const [lastYearTotalCount, lastYearSelectedCount, lastYearFinishedCount, lastYearUnivCount] = lastYearOverviewRes[0];
   const finishedRatio = Math.round(finishedCount * 100 / totalCount);
+  const lastYearFinishedRatio = Math.round(lastYearFinishedCount * 100 / lastYearTotalCount);
   console.log('项目总数: ', totalCount);
   console.log('中选项目数: ', selectedCount);
   console.log('结项项目数: ', finishedCount);
   console.log('项目率: ', finishedRatio);
   console.log('高校数量: ', univCount);
+  console.log(JSON.stringify({
+    year,
+    totalCount,
+    selectedCount,
+    finishedCount,
+    univCount,
+    finishedRatio,
+    totalCountDelta: totalCount - lastYearTotalCount,
+    selectedCountDelta: selectedCount - lastYearSelectedCount,
+    finishedCountDelta: finishedCount - lastYearFinishedCount,
+    univCountDelta: univCount - lastYearUnivCount,
+    finishedRatioDelta: finishedRatio - lastYearFinishedRatio,
+  }));
 
   const platformDistributionRes = await query<any>(`SELECT
     repos.platform[1] AS platform,
@@ -34,25 +57,87 @@ const analysisData = async (year: number) => {
     JSON.stringify(finishUnivDistributionRes.filter(n => n[1] >= 2).map(n => ({ name: n[0], value: n[1] }))));
 
   const studentLoginMap = new Map<string, any[]>([['GitHub', []], ['Gitee', []]]);
-  const reposMap = new Map<string, any[]>([['GitHub', []], ['Gitee', []]]);
+  const reposMap = new Map<number, Map<string, any[]>>([
+    [year, new Map<string, any[]>([['GitHub', []], ['Gitee', []]])],
+    [year - 1, new Map<string, any[]>([['GitHub', []], ['Gitee', []]])]
+  ]);
 
-  rawData.filter(r => r.state === 'Finished')
-    .forEach(r => {
-      studentLoginMap.get(r.student_platform)?.push(r.student_login);
-      for (let i = 0; i < r['repos.platform'].length; i++) {
-        reposMap.get(r['repos.platform'][i])?.push(r['repos.name'][i]);
-      }
+  for (const y of [year, year - 1]) {
+    rawDataMap.get(y)!.filter(r => r.state === 'Finished')
+      .forEach(r => {
+        studentLoginMap.get(r.student_platform)?.push(r.student_login);
+        for (let i = 0; i < r['repos.platform'].length; i++) {
+          reposMap.get(y)!.get(r['repos.platform'][i])?.push(r['repos.name'][i]);
+        }
+      });
+  }
+
+  const getUnivRankingData = async (y: number) => {
+    const studentOpenRankRes = await getUserCommunityOpenrank({
+      startYear: y, startMonth: 1, endYear: y, endMonth: 12,
+      idOrNames: [{
+        platform: 'GitHub',
+        repoNames: reposMap.get(y)!.get('GitHub')!,
+        userLogins: studentLoginMap.get('GitHub')!,
+      }, {
+        platform: 'Gitee',
+        repoNames: reposMap.get(y)!.get('Gitee')!,
+        userLogins: studentLoginMap.get('Gitee')!,
+      }],
+      groupTimeRange: 'year',
+      order: 'DESC', orderOption: 'latest',
+      limit: -1, limitOption: 'all', precision: 2,
     });
 
+    const studentOpenRankData = studentOpenRankRes.map(row => ({
+      login: row.name,
+      openrank: row.openrank[0],
+      platform: row.platform,
+    }));
+
+    const univOpenrankRankingMap = new Map<string, { count: number; openrank: number }>();
+    for (const s of studentOpenRankData) {
+      const record = rawDataMap.get(y)!.find(r => r.student_login === s.login && r.student_platform === s.platform)!;
+      if (!record) continue;
+      const univ = record.student_univ;
+      if (!univOpenrankRankingMap.has(univ)) univOpenrankRankingMap.set(univ, { count: 0, openrank: 0 });
+      univOpenrankRankingMap.get(univ)!.count++;
+      univOpenrankRankingMap.get(univ)!.openrank += s.openrank;
+    }
+    const univOpenrankRankingList = Array.from(univOpenrankRankingMap.entries()).map(r => ({
+      univ: r[0],
+      count: r[1].count,
+      openrank: +(r[1].openrank.toFixed(2)),
+    })).sort((a, b) => b.openrank - a.openrank);
+    return univOpenrankRankingList;
+  };
+
+  const univOpenrankRankingList = await getUnivRankingData(year);
+  const lastYearUnivOpenrankRankingList = await getUnivRankingData(year - 1);
+  const univeData = univOpenrankRankingList.slice(0, 20).map((u, index) => {
+    const lastYearUnivOpenrankRanking = lastYearUnivOpenrankRankingList.find(r => r.univ === u.univ);
+    return {
+      __index__: index + 1,
+      name: u.univ,
+      openrank: u.openrank,
+      openrankDelta: lastYearUnivOpenrankRanking ? +(u.openrank - lastYearUnivOpenrankRanking.openrank).toFixed(2) : '-',
+      totalCount: u.count,
+      totalCountDelta: lastYearUnivOpenrankRanking ? u.count - lastYearUnivOpenrankRanking.count : '-',
+      openrankAverage: +(u.openrank / u.count).toFixed(2),
+      openrankAverageDelta: lastYearUnivOpenrankRanking ? +((u.openrank / u.count) - (lastYearUnivOpenrankRanking.openrank / lastYearUnivOpenrankRanking.count)).toFixed(2) : '-',
+    };
+  });
+  console.log(JSON.stringify(univeData));
+
   const studentOpenRankRes = await getUserCommunityOpenrank({
-    startYear: 2024, startMonth: 1, endYear: 2024, endMonth: 12,
+    startYear: year, startMonth: 1, endYear: year, endMonth: 12,
     idOrNames: [{
       platform: 'GitHub',
-      repoNames: reposMap.get('GitHub')!,
+      repoNames: reposMap.get(year)!.get('GitHub')!,
       userLogins: studentLoginMap.get('GitHub')!,
     }, {
       platform: 'Gitee',
-      repoNames: reposMap.get('Gitee')!,
+      repoNames: reposMap.get(year)!.get('Gitee')!,
       userLogins: studentLoginMap.get('Gitee')!,
     }],
     groupTimeRange: 'year',
@@ -65,52 +150,24 @@ const analysisData = async (year: number) => {
     openrank: row.openrank[0],
     platform: row.platform,
   }));
-
-  const univOpenrankRankingMap = new Map<string, { count: number; openrank: number }>();
-  for (const s of studentOpenRankData) {
-    const record = rawData.find(r => r.student_login === s.login && r.student_platform === s.platform)!;
-    if (!record) continue;
-    const univ = record.student_univ;
-    if (!univOpenrankRankingMap.has(univ)) univOpenrankRankingMap.set(univ, { count: 0, openrank: 0 });
-    univOpenrankRankingMap.get(univ)!.count++;
-    univOpenrankRankingMap.get(univ)!.openrank += s.openrank;
-  }
-  const univOpenrankRankingList = Array.from(univOpenrankRankingMap.entries()).map(r => ({
-    univ: r[0],
-    count: r[1].count,
-    openrank: +(r[1].openrank.toFixed(2)),
-  })).sort((a, b) => b.openrank - a.openrank);
-  console.table(univOpenrankRankingList.slice(0, 20));
-  const data2024 = univOpenrankRankingList.slice(0, 20).map((u, index) => {
+  const studentOpenrankRankingList = studentOpenRankData.map(s => {
+    const record = rawDataMap.get(year)!.find(r => r.student_login === s.login && r.student_platform === s.platform)!;
+    if (!record) return null;
     return {
-      __index__: index + 1,
-      name: u.univ,
-      openrank: u.openrank,
-      openrankDelta: '-',
-      totalCount: u.count,
-      totalCountDelta: '-',
-      openrankAverage: +(u.openrank / u.count).toFixed(2),
-      openrankAverageDelta: '-',
-    };
-  });
-  console.log(JSON.stringify(data2024));
-
-  const studentOpenrankRankingList = studentOpenRankData.slice(0, 20).map((s, index) => {
-    const record = rawData.find(r => r.student_login === s.login && r.student_platform === s.platform)!;
-    if (!record) return {};
-    return {
-      __index__: index + 1,
       name: record.student_name[0] + '*'.repeat(record.student_name.length - 1),
       openrank: s.openrank,
       univ: record.student_univ,
       community: record.community,
     }
-  });
+  }).filter(r => r !== null).slice(0, 20).map((r, index) => ({
+    ...r,
+    __index__: index + 1,
+  }));
   console.table(studentOpenrankRankingList);
   console.log(JSON.stringify(studentOpenrankRankingList));
 
   const studentGlobalOpenRankRes = await getUserCommunityOpenrank({
-    startYear: 2024, startMonth: 1, endYear: 2024, endMonth: 12,
+    startYear: year, startMonth: 1, endYear: year, endMonth: 12,
     idOrNames: [{
       platform: 'GitHub',
       userLogins: studentLoginMap.get('GitHub')!,
@@ -122,23 +179,25 @@ const analysisData = async (year: number) => {
     order: 'DESC', orderOption: 'latest',
     limit: -1, limitOption: 'all', precision: 2,
   });
-  const studentGlobalOpenrankRankingList = studentGlobalOpenRankRes.slice(0, 10).map((s, index) => {
+  const studentGlobalOpenrankRankingList = studentGlobalOpenRankRes.map(s => {
     const openrank = s.openrank[0];
-    const openrankDetails = s.openrankDetails[0].map(r => r[2]);
-    const record = rawData.find(r => r.student_login === s.name && r.student_platform === s.platform)!;
-    if (!record) return {};
+    const openrankDetails = s.details[0].map(r => r[2]);
+    const record = rawDataMap.get(year)!.find(r => r.student_login === s.name && r.student_platform === s.platform)!;
+    if (!record) return null;
     return {
-      __index__: index + 1,
-      name: record.student_name[0] + '*'.repeat(record.student_name.length - 1),
+      name: (record.student_name[0] + '*'.repeat(record.student_name.length - 1)).slice(0, 5),
       openrank,
       univ: record.student_univ,
       repos: openrankDetails.slice(0, 3).join('<br />'),
     };
-  });
+  }).filter(r => r !== null).slice(0, 10).map((r, index) => ({
+    ...r,
+    __index__: index + 1,
+  }));
   console.table(studentGlobalOpenrankRankingList);
   console.log(JSON.stringify(studentGlobalOpenrankRankingList));
 };
 
 (async () => {
-  await analysisData(2024);
+  await analysisData(2025);
 })();

--- a/src/metrics/basic.ts
+++ b/src/metrics/basic.ts
@@ -5,7 +5,8 @@ import { PlatformNames, OptionLabelItem, getPlatformData } from '../labelDataUti
 export interface QueryConfig<T = any> {
   labelUnion?: string[];
   labelIntersect?: string[];
-  label?: OptionLabelItem;
+  repoLabel?: OptionLabelItem;
+  userLabel?: OptionLabelItem;
   idOrNames?: {
     platform: PlatformNames;
     repoIds?: number[];
@@ -102,8 +103,8 @@ export const forEveryYearByConfig = async (config: QueryConfig, func: (y: number
 };
 
 export const getWithClause = (config: QueryConfig): string => {
-  if (config.label) {
-    return `WITH ${config.label.withParamClause}`;
+  if (config.repoLabel) {
+    return `WITH ${config.repoLabel.withParamClause}`;
   }
   return '';
 }
@@ -159,8 +160,8 @@ export const getRepoWhereClause = async (config: QueryConfig): Promise<string | 
     }
   }
 
-  if (config.label) {
-    repoWhereClauseArray.push(config.label.repoWhereClause);
+  if (config.repoLabel) {
+    repoWhereClauseArray.push(config.repoLabel.repoWhereClause);
   }
 
   // where clause
@@ -212,8 +213,8 @@ export const getUserWhereClause = async (config: QueryConfig, idCol: string = 'a
     }
   }
 
-  if (config.label) {
-    userWhereClauseArray.push(config.label.userWhereClause);
+  if (config.userLabel) {
+    userWhereClauseArray.push(config.userLabel.userWhereClause);
   }
 
   // where clause
@@ -299,9 +300,9 @@ export const getOutterOrderAndLimit = (config: QueryConfig, col: string, index?:
 
 export const getTopLevelPlatform = (config: QueryConfig, noCount = false) => {
   if (!noCount && (config.groupBy && config.groupBy !== 'org' && config.groupBy !== 'repo')) {
-    return `'All' AS platform, ${getGroupArrayInsertAtClause(config, { key: 'repos' })}, ${getGroupArrayInsertAtClause(config, { key: 'orgs' })}, ${getGroupArrayInsertAtClause(config, { key: 'developers' })}`;
+    return `'All' AS platform`;
   } else {
-    return 'platform, 1 AS repos, 1 AS orgs, 1 AS developers';
+    return 'platform';
   }
 };
 
@@ -334,7 +335,7 @@ export const filterEnumType = (value: any, types: string[], defautlValue: string
 
 export const processQueryResult = (result: any, customKeys: string[],
   postProcessor?: { [key: string]: (value: any) => any }): any[] => {
-  const keys = ['id', 'platform', 'repos', 'orgs', 'developers', 'name', ...customKeys];
+  const keys = ['id', 'platform', 'name', ...customKeys];
   return result.map((r: any) => {
     const obj: any = {};
     keys.forEach((k, i) => {

--- a/src/scripts/createViews.ts
+++ b/src/scripts/createViews.ts
@@ -1,5 +1,4 @@
-import { getNewClient, query } from "../db/clickhouse";
-import { basicActivitySqlComponent } from "../metrics/indices";
+import { query } from "../db/clickhouse";
 
 (async () => {
   const createUserView = async () => {
@@ -250,124 +249,6 @@ GROUP BY id, platform
     await query(createViewQuery);
   };
 
-  const createNormalizedCommunityOpenRankView = async () => {
-    // The normalized_community_openrank view is used to store the normalized community openrank info for the all repos
-    // The normalized_community_openrank view is refreshed every 1 day
-    // The normalized_community_openrank is calculated by the community openrank and the global openrank
-    // The normalized_community_openrank uses activity instead of community openrank if it is not calculated
-    const client = await getNewClient();
-    await client.command({ query: `DROP TABLE IF EXISTS normalized_community_openrank` });
-    await client.command({
-      query: `
-    CREATE MATERIALIZED VIEW IF NOT EXISTS normalized_community_openrank
-    (
-       platform LowCardinality(String),
-       repo_id UInt64,
-       repo_name LowCardinality(String),
-       org_id UInt64,
-       org_login LowCardinality(String),
-       actor_id UInt64,
-       actor_login LowCardinality(String),
-       openrank Float,
-       yyyymm UInt32,
-       created_at DateTime
-    )
-    ENGINE = MergeTree()
-    ORDER BY (repo_id, platform)
-    POPULATE
-    AS
-    SELECT platform, repo_id, repo_name, org_id, org_login, actor_id, actor_login, openrank, yyyymm, created_at FROM
-    (
-      SELECT
-        g.platform,
-        g.repo_id,
-        g.repo_name,
-        g.org_id,
-        g.org_login,
-        g.created_at,
-        arrayJoin(arrayMap(x -> tuple(x.1, x.2, g.openrank * x.3 / gor), c.gor_details)) AS openrank_arr,
-        openrank_arr.1 AS actor_id,
-        openrank_arr.2 AS actor_login,
-        openrank_arr.3 AS openrank,
-        toYYYYMM(c.created_at) AS yyyymm
-      FROM
-      (SELECT platform, repo_id, repo_name, org_id, org_login, openrank, created_at
-        FROM global_openrank WHERE type = 'Repo') g
-      INNER JOIN
-      ((SELECT repo_id, platform, SUM(openrank) AS gor, groupArray(tuple(actor_id, actor_login, openrank)) AS gor_details, created_at
-        FROM community_openrank WHERE actor_id > 0 AND actor_login NOT LIKE '%[bot]' AND
-        (platform, actor_id) NOT IN (SELECT platform, entity_id FROM flatten_labels WHERE id = ':bot' AND entity_type = 'User')
-        GROUP BY repo_id, platform, created_at)
-        UNION ALL
-        (SELECT repo_id, platform, SUM(activity) AS gor, groupArray(tuple(actor_id, actor_login, activity)) AS gor_details, m AS created_at
-        FROM (
-          SELECT repo_id, platform, ${basicActivitySqlComponent}, toStartOfMonth(created_at) AS m
-          FROM events WHERE
-          (platform, actor_id) NOT IN (SELECT platform, entity_id FROM flatten_labels WHERE id = ':bot' AND entity_type = 'User')
-          AND type IN ('IssuesEvent', 'IssueCommentEvent', 'PullRequestEvent', 'PullRequestReviewCommentEvent')
-          AND (repo_id, platform) NOT IN (SELECT id, platform FROM export_repo)
-          GROUP BY repo_id, platform, actor_id, m
-          HAVING actor_login NOT LIKE '%[bot]'
-        )
-        GROUP BY repo_id, platform, created_at)
-      ) c
-      ON g.repo_id = c.repo_id AND g.created_at = c.created_at AND g.platform = c.platform
-      WHERE openrank > 0
-    )`,
-    });
-    console.log('Create normalized_community_openrank view done.');
-    await client.command({ query: `DROP TABLE IF EXISTS normalized_community_openrank_with_bot` });
-    await client.command({
-      query: `
-CREATE MATERIALIZED VIEW IF NOT EXISTS normalized_community_openrank_with_bot
-(
-   platform LowCardinality(String),
-   repo_id UInt64,
-   repo_name LowCardinality(String),
-   org_id UInt64,
-   org_login LowCardinality(String),
-   actor_id UInt64,
-   actor_login LowCardinality(String),
-   openrank Float,
-   is_bot UInt8,
-   yyyymm UInt32,
-   created_at DateTime
-)
-ENGINE = MergeTree()
-ORDER BY (repo_id, platform)
-POPULATE
-AS
-SELECT platform, repo_id, repo_name, org_id, org_login, actor_id, actor_login, openrank, 
-if(actor_login LIKE '%[bot]' OR (platform, actor_id) IN (SELECT platform, entity_id FROM flatten_labels WHERE id = ':bot' AND entity_type = 'User'), 1, 0) AS is_bot,
-yyyymm, created_at FROM
-(
-  SELECT
-    g.platform,
-    g.repo_id,
-    g.repo_name,
-    g.org_id,
-    g.org_login,
-    g.created_at,
-    arrayJoin(arrayMap(x -> tuple(x.1, x.2, g.openrank * x.3 / gor), c.gor_details)) AS openrank_arr,
-    openrank_arr.1 AS actor_id,
-    openrank_arr.2 AS actor_login,
-    openrank_arr.3 AS openrank,
-    toYYYYMM(c.created_at) AS yyyymm
-  FROM
-  (SELECT platform, repo_id, repo_name, org_id, org_login, openrank, created_at
-    FROM global_openrank WHERE type = 'Repo') g
-  INNER JOIN
-  (SELECT repo_id, platform, SUM(openrank) AS gor, groupArray(tuple(actor_id, actor_login, openrank)) AS gor_details, created_at
-    FROM community_openrank WHERE actor_id > 0
-    GROUP BY repo_id, platform, created_at) c
-  ON g.repo_id = c.repo_id AND g.created_at = c.created_at AND g.platform = c.platform
-  WHERE openrank > 0
-)`,
-    });
-    console.log('Create normalized_community_openrank_with_bot view done.');
-    await client.close();
-  };
-
   const createLabelHierarchyView = async () => {
     await query(`DROP TABLE IF EXISTS label_hierarchy`);
     const createViewQuery = `
@@ -433,6 +314,5 @@ GROUP BY id, parent_id
   await createFlattenLabelView();
   await createPullsWitLabelView();
   await createIssuesWithLabelView();
-  await createNormalizedCommunityOpenRankView();
   await createLabelHierarchyView();
 })();

--- a/src/scripts/importNormalizedCommunityOpenrank.ts
+++ b/src/scripts/importNormalizedCommunityOpenrank.ts
@@ -1,0 +1,136 @@
+import { query } from "../db/clickhouse";
+import { forEveryMonth } from "../metrics/basic";
+import { basicActivitySqlComponent } from "../metrics/indices";
+import { getLogger } from "../utils";
+
+const logger = getLogger('ImportNormalizedCommunityOpenrank');
+const importNormalizedCommunityOpenrank = async () => {
+  // The normalized_community_openrank view is used to store the normalized community openrank info for the all repos
+  // The normalized_community_openrank is calculated by the community openrank and the global openrank
+  // The normalized_community_openrank uses activity instead of community openrank if it is not calculated
+  // await query(`DROP TABLE IF EXISTS normalized_community_openrank`);
+  // await query(`DROP TABLE IF EXISTS normalized_community_openrank_with_bot`);
+  await query(`CREATE TABLE IF NOT EXISTS normalized_community_openrank
+    (
+       platform LowCardinality(String),
+       repo_id UInt64,
+       repo_name LowCardinality(String),
+       org_id UInt64,
+       org_login LowCardinality(String),
+       actor_id UInt64,
+       actor_login LowCardinality(String),
+       openrank Float,
+       yyyymm UInt32,
+       created_at DateTime
+    )
+    ENGINE = MergeTree()
+    ORDER BY (repo_id, platform)`);
+  await query(`CREATE TABLE IF NOT EXISTS normalized_community_openrank_with_bot
+    (
+       platform LowCardinality(String),
+       repo_id UInt64,
+       repo_name LowCardinality(String),
+       org_id UInt64,
+       org_login LowCardinality(String),
+       actor_id UInt64,
+       actor_login LowCardinality(String),
+       openrank Float,
+       is_bot UInt8,
+       yyyymm UInt32,
+       created_at DateTime
+    )
+    ENGINE = MergeTree()
+    ORDER BY (repo_id, platform)`);
+  const maxYyyymm = await query(`SELECT MAX(yyyymm) FROM normalized_community_openrank`);
+  let maxYyyymmValue: number = 201012;
+  if (maxYyyymm.length > 0 && maxYyyymm[0] !== null && maxYyyymm[0][0] !== null && maxYyyymm[0][0] !== 0) {
+    maxYyyymmValue = +maxYyyymm[0][0];
+  }
+  const minYear = Math.floor(maxYyyymmValue / 100);
+  const minMonth = maxYyyymmValue % 100;
+  const startDate = new Date(minYear, minMonth - 1, 1);
+  startDate.setMonth(startDate.getMonth() + 1);
+  const startYear = startDate.getFullYear();
+  const startMonth = startDate.getMonth() + 1;
+  const lastMonth = new Date();
+  lastMonth.setMonth(lastMonth.getMonth() - 1);
+  const endYear = lastMonth.getFullYear();
+  const endMonth = lastMonth.getMonth() + 1;
+  logger.info(`Import normalized community openrank from ${startYear}-${startMonth} to ${endYear}-${endMonth}`);
+  await forEveryMonth(startYear, startMonth, endYear, endMonth, async (y, m) => {
+    const yyyymm = y.toString() + m.toString().padStart(2, '0');
+    await query(`INSERT INTO normalized_community_openrank
+    SELECT platform, repo_id, repo_name, org_id, org_login, actor_id, actor_login, openrank, yyyymm, created_at FROM
+    (
+      SELECT
+        g.platform,
+        g.repo_id,
+        g.repo_name,
+        g.org_id,
+        g.org_login,
+        g.created_at,
+        arrayJoin(arrayMap(x -> tuple(x.1, x.2, g.openrank * x.3 / gor), c.gor_details)) AS openrank_arr,
+        openrank_arr.1 AS actor_id,
+        openrank_arr.2 AS actor_login,
+        openrank_arr.3 AS openrank,
+        toYYYYMM(c.created_at) AS yyyymm
+      FROM
+      (SELECT platform, repo_id, repo_name, org_id, org_login, openrank, created_at
+        FROM global_openrank WHERE type = 'Repo' AND toYYYYMM(created_at) = ${yyyymm}) g
+      INNER JOIN
+      ((SELECT repo_id, platform, SUM(openrank) AS gor, groupArray(tuple(actor_id, actor_login, openrank)) AS gor_details, created_at
+        FROM community_openrank WHERE toYYYYMM(created_at) = ${yyyymm} AND actor_id > 0 AND actor_login NOT LIKE '%[bot]' AND
+        (platform, actor_id) NOT IN (SELECT platform, entity_id FROM flatten_labels WHERE id = ':bot' AND entity_type = 'User')
+        GROUP BY repo_id, platform, created_at)
+        UNION ALL
+        (SELECT repo_id, platform, SUM(activity) AS gor, groupArray(tuple(actor_id, actor_login, activity)) AS gor_details, m AS created_at
+        FROM (
+          SELECT repo_id, platform, ${basicActivitySqlComponent}, toStartOfMonth(created_at) AS m
+          FROM events WHERE
+          toYYYYMM(created_at) = ${yyyymm} AND
+          (platform, actor_id) NOT IN (SELECT platform, entity_id FROM flatten_labels WHERE id = ':bot' AND entity_type = 'User')
+          AND type IN ('IssuesEvent', 'IssueCommentEvent', 'PullRequestEvent', 'PullRequestReviewCommentEvent')
+          AND (repo_id, platform) NOT IN (SELECT id, platform FROM export_repo)
+          GROUP BY repo_id, platform, actor_id, m
+          HAVING actor_login NOT LIKE '%[bot]'
+        )
+        GROUP BY repo_id, platform, created_at)
+      ) c
+      ON g.repo_id = c.repo_id AND g.created_at = c.created_at AND g.platform = c.platform
+      WHERE openrank > 0
+    )`);
+    await query(`INSERT INTO normalized_community_openrank_with_bot
+    SELECT platform, repo_id, repo_name, org_id, org_login, actor_id, actor_login, openrank, 
+    if(actor_login LIKE '%[bot]' OR (platform, actor_id) IN (SELECT platform, entity_id FROM flatten_labels WHERE id = ':bot' AND entity_type = 'User'), 1, 0) AS is_bot,
+    yyyymm, created_at FROM
+    (
+      SELECT
+        g.platform,
+        g.repo_id,
+        g.repo_name,
+        g.org_id,
+        g.org_login,
+        g.created_at,
+        arrayJoin(arrayMap(x -> tuple(x.1, x.2, g.openrank * x.3 / gor), c.gor_details)) AS openrank_arr,
+        openrank_arr.1 AS actor_id,
+        openrank_arr.2 AS actor_login,
+        openrank_arr.3 AS openrank,
+        toYYYYMM(c.created_at) AS yyyymm
+      FROM
+      (SELECT platform, repo_id, repo_name, org_id, org_login, openrank, created_at
+        FROM global_openrank WHERE type = 'Repo' AND toYYYYMM(created_at) = ${yyyymm}) g
+      INNER JOIN
+      (SELECT repo_id, platform, SUM(openrank) AS gor, groupArray(tuple(actor_id, actor_login, openrank)) AS gor_details, created_at
+        FROM community_openrank WHERE toYYYYMM(created_at) = ${yyyymm} AND actor_id > 0
+        GROUP BY repo_id, platform, created_at) c
+      ON g.repo_id = c.repo_id AND g.created_at = c.created_at AND g.platform = c.platform
+      WHERE openrank > 0
+      )`);
+    logger.info(`Import normalized community openrank for ${yyyymm} done.`);
+  });
+  logger.info('Import normalized community openrank done.');
+};
+
+(async () => {
+  await importNormalizedCommunityOpenrank();
+})();

--- a/src/scripts/leaderboardNext.ts
+++ b/src/scripts/leaderboardNext.ts
@@ -73,7 +73,7 @@ import { existsSync, mkdirSync, writeFileSync } from "fs";
           precision: 2,
           groupBy: groupType,
           groupTimeRange: groupByTimeType,
-          label: scopeLabel ? LabelUtil.get(scopeLabel) : undefined,
+          repoLabel: scopeLabel ? LabelUtil.get(scopeLabel) : undefined,
         };
         const openrankData = await getRepoOpenrank(options);
         let idOrNames: any = undefined;


### PR DESCRIPTION
This pull request introduces several improvements and refactors to the data production and metrics calculation logic, mainly focusing on supporting year-over-year comparisons, improving label handling, and simplifying the data structures used in queries and results. The most significant changes are grouped below.

**Enhancements to OSPP Data Analysis and Year-over-Year Comparison:**

- The `analysisData` function in `ospp.ts` now fetches and processes data for both the current and previous years, enabling year-over-year metrics and delta calculations for project counts, selected/finished projects, university counts, and ratios. University and student OpenRank rankings are now compared year-over-year, with delta fields included in the output. [[1]](diffhunk://#diff-94d6f65796b7c5069d8ed426f36aa8ed64d9d474bde131cb1897bd599dfecb76L6-R43) [[2]](diffhunk://#diff-94d6f65796b7c5069d8ed426f36aa8ed64d9d474bde131cb1897bd599dfecb76L37-R84) [[3]](diffhunk://#diff-94d6f65796b7c5069d8ed426f36aa8ed64d9d474bde131cb1897bd599dfecb76L71-R100) [[4]](diffhunk://#diff-94d6f65796b7c5069d8ed426f36aa8ed64d9d474bde131cb1897bd599dfecb76L83-R170) [[5]](diffhunk://#diff-94d6f65796b7c5069d8ed426f36aa8ed64d9d474bde131cb1897bd599dfecb76L125-R202)

**Refactoring and Consistency in Label Handling:**

- The `QueryConfig` interface and related functions were updated to use `repoLabel` and `userLabel` instead of a generic `label` field, improving clarity and flexibility when building query clauses for repositories and users. All relevant SQL clause generators and query logic were updated accordingly. [[1]](diffhunk://#diff-99ebc3e8b8b06ef742d71fbd430d0e44fa8ee446dc2d86c737e2e3d6c72d61b5L8-R9) [[2]](diffhunk://#diff-99ebc3e8b8b06ef742d71fbd430d0e44fa8ee446dc2d86c737e2e3d6c72d61b5L105-R107) [[3]](diffhunk://#diff-99ebc3e8b8b06ef742d71fbd430d0e44fa8ee446dc2d86c737e2e3d6c72d61b5L162-R164) [[4]](diffhunk://#diff-99ebc3e8b8b06ef742d71fbd430d0e44fa8ee446dc2d86c737e2e3d6c72d61b5L215-R217)
- In `communityOpenrankLeaderboards.ts`, label handling was refactored to use `LabelUtil.union` and `LabelUtil.get`, aligning with the new label configuration structure. [[1]](diffhunk://#diff-31d014f90a73732e25a0ffc31548f4b7d1f5cdd2db65a80ec74f759017715c7dL7-R7) [[2]](diffhunk://#diff-31d014f90a73732e25a0ffc31548f4b7d1f5cdd2db65a80ec74f759017715c7dL83-R87)

**Query Structure and Result Simplification:**

- The SQL query generation in `getTopLevelPlatform` and `processQueryResult` was simplified by removing unnecessary columns (`repos`, `orgs`, `developers`) from the top-level platform and result processing logic, streamlining the output. [[1]](diffhunk://#diff-99ebc3e8b8b06ef742d71fbd430d0e44fa8ee446dc2d86c737e2e3d6c72d61b5L302-R305) [[2]](diffhunk://#diff-99ebc3e8b8b06ef742d71fbd430d0e44fa8ee446dc2d86c737e2e3d6c72d61b5L337-R338)

**Leaderboard Data Improvements:**

- Leaderboard data is now consistently sorted by OpenRank before output, and the correct data fields (`details` instead of `openrank`) are used in the leaderboard output, ensuring accurate and meaningful results. [[1]](diffhunk://#diff-31d014f90a73732e25a0ffc31548f4b7d1f5cdd2db65a80ec74f759017715c7dL102-R105) [[2]](diffhunk://#diff-31d014f90a73732e25a0ffc31548f4b7d1f5cdd2db65a80ec74f759017715c7dL138-R146)

**Code Cleanup:**

- Removed unused imports, such as `getPlatformData` from `indices.ts`, to keep the codebase clean.

These changes collectively improve the accuracy, clarity, and maintainability of the data production and metrics modules.