### PR TITLE
label: add 9 unlabeled high-OpenRank repos to agentic_ai

### DIFF
--- a/labeled_data/companies/coder/coder.yml
+++ b/labeled_data/companies/coder/coder.yml
@@ -1,0 +1,11 @@
+name: Coder
+description: Secure environments for developers and their agents
+description_zh: 为开发者及其智能体提供安全环境
+type: Project
+
+  platforms:
+    - name: GitHub
+      type: Code Hosting
+      orgs:
+        - id: 95932066
+          name: coder

--- a/labeled_data/companies/coder/index.yml
+++ b/labeled_data/companies/coder/index.yml
@@ -1,0 +1,5 @@
+name: Coder
+type: Company
+
+  labels:
+    - coder

--- a/labeled_data/companies/daytona/daytona.yml
+++ b/labeled_data/companies/daytona/daytona.yml
@@ -1,0 +1,11 @@
+name: Daytona
+description: Secure and Elastic Infrastructure for Running AI-Generated Code
+description_zh: 用于运行 AI 生成代码的安全弹性基础设施
+type: Project
+
+  platforms:
+    - name: GitHub
+      type: Code Hosting
+      orgs:
+        - id: 130513197
+          name: daytonaio

--- a/labeled_data/companies/daytona/index.yml
+++ b/labeled_data/companies/daytona/index.yml
@@ -1,0 +1,5 @@
+name: Daytona
+type: Company
+
+  labels:
+    - daytona

--- a/labeled_data/projects/cli_proxy_api.yml
+++ b/labeled_data/projects/cli_proxy_api.yml
@@ -1,0 +1,11 @@
+name: CLIProxyAPI
+description: Wrap Gemini CLI, Antigravity, ChatGPT Codex, Claude Code as an OpenAI/Gemini/Claude/Codex compatible API service
+description_zh: 将 Gemini CLI、Antigravity、ChatGPT Codex、Claude Code 封装为兼容 OpenAI/Gemini/Claude/Codex 的 API 服务
+type: Project
+
+  platforms:
+    - name: GitHub
+      type: Code Hosting
+      orgs:
+        - id: 233033915
+          name: router-for-me

--- a/labeled_data/projects/hive.yml
+++ b/labeled_data/projects/hive.yml
@@ -1,0 +1,11 @@
+name: Hive
+description: Multi-Agent Harness for Production AI
+description_zh: 面向生产级 AI 的多智能体框架
+type: Project
+
+  platforms:
+    - name: GitHub
+      type: Code Hosting
+      orgs:
+        - id: 262650699
+          name: aden-hive

--- a/labeled_data/projects/kilocode.yml
+++ b/labeled_data/projects/kilocode.yml
@@ -1,0 +1,11 @@
+name: Kilocode
+description: The all-in-one agentic engineering platform
+description_zh: 一站式智能体工程平台
+type: Project
+
+  platforms:
+    - name: GitHub
+      type: Code Hosting
+      orgs:
+        - id: 201822503
+          name: Kilo-Org

--- a/labeled_data/projects/zeroclaw.yml
+++ b/labeled_data/projects/zeroclaw.yml
@@ -1,0 +1,11 @@
+name: ZeroClaw
+description: Fast, small, and fully autonomous AI personal assistant infrastructure
+description_zh: 快速、轻量且完全自主的 AI 个人助手基础设施
+type: Project
+
+  platforms:
+    - name: GitHub
+      type: Code Hosting
+      orgs:
+        - id: 261820148
+          name: zeroclaw-labs

--- a/labeled_data/technology/agentic_ai/agent/agent_framework/index.yml
+++ b/labeled_data/technology/agentic_ai/agent/agent_framework/index.yml
@@ -3,6 +3,7 @@ type: Tech-2
 data:
   labels:
     - :projects/openclaw
+    - :projects/hive
   platforms:
     - name: GitHub
       type: Code Hosting

--- a/labeled_data/technology/agentic_ai/agent/agent_tool/index.yml
+++ b/labeled_data/technology/agentic_ai/agent/agent_tool/index.yml
@@ -1,7 +1,9 @@
 name: Agent Tool
 type: Tech-2
 data:
-  labels: []
+  labels:
+    - :companies/daytona/daytona
+    - :projects/cli_proxy_api
   platforms:
     - name: GitHub
       type: Code Hosting
@@ -30,3 +32,5 @@ data:
           name: ComposioHQ/composio
         - id: 631254164
           name: songquanpeng/one-api
+        - id: 717197250
+          name: QuantumNous/new-api

--- a/labeled_data/technology/agentic_ai/agent/ai_coding/index.yml
+++ b/labeled_data/technology/agentic_ai/agent/ai_coding/index.yml
@@ -4,6 +4,9 @@ data:
   labels:
     - :companies/anthropic/claude_code
     - :companies/anomaly/opencode
+    - :companies/coder/coder
+    - :projects/zeroclaw
+    - :projects/kilocode
   platforms:
     - name: GitHub
       type: Code Hosting
@@ -36,3 +39,7 @@ data:
           name: Aider-AI/aider
         - id: 614764248
           name: TabbyML/tabby
+        - id: 1031912724
+          name: farion1231/cc-switch
+        - id: 1002125012
+          name: BloopAI/vibe-kanban


### PR DESCRIPTION
Add repos from llm-oss-landscape CSV top 100 that were not yet labeled in open-digger's agentic_ai category:

Org-level labels (new project/company files):
- aden-hive/hive → agent/agent_framework
- zeroclaw-labs/zeroclaw → agent/ai_coding
- coder/coder → agent/ai_coding
- Kilo-Org/kilocode → agent/ai_coding
- router-for-me/CLIProxyAPI → agent/agent_tool
- daytonaio/daytona → agent/agent_tool

Repo-level entries:
- farion1231/cc-switch → agent/ai_coding
- BloopAI/vibe-kanban → agent/ai_coding
- QuantumNous/new-api → agent/agent_tool