### PR TITLE
label: Update data for Database technical area labeled on dbdb.io and DB-Engines Ranking up to May 31, 2026.

### DIFF
--- a/labeled_data/technology/database/array.yml
+++ b/labeled_data/technology/database/array.yml
@@ -8,6 +8,8 @@ data:
       repos:
         - id: 534109388
           name: EuclidOLAP/EuclidOLAP
+        - id: 1183612568
+          name: NodeDB-Lab/nodedb
         - id: 86868560
           name: TileDB-Inc/TileDB
         - id: 31373521

--- a/labeled_data/technology/database/document.yml
+++ b/labeled_data/technology/database/document.yml
@@ -56,6 +56,8 @@ data:
           name: Lona-Development/Server
         - id: 50098469
           name: Nexedi/neoppod
+        - id: 1183612568
+          name: NodeDB-Lab/nodedb
         - id: 284225188
           name: PoloDB/PoloDB
         - id: 188354257

--- a/labeled_data/technology/database/graph.yml
+++ b/labeled_data/technology/database/graph.yml
@@ -22,6 +22,8 @@ data:
           name: JanusGraph/janusgraph
         - id: 1071734040
           name: LadybugDB/ladybug
+        - id: 1183612568
+          name: NodeDB-Lab/nodedb
         - id: 92834468
           name: Pometry/Raphtory
         - id: 45098765

--- a/labeled_data/technology/database/key_value.yml
+++ b/labeled_data/technology/database/key_value.yml
@@ -90,6 +90,8 @@ data:
           name: akrylysov/pogreb
         - id: 161674141
           name: alash3al/redix
+        - id: 926191450
+          name: ankur-anand/unisondb
         - id: 206424
           name: apache/cassandra
         - id: 34839383

--- a/labeled_data/technology/database/relational.yml
+++ b/labeled_data/technology/database/relational.yml
@@ -84,6 +84,8 @@ data:
           name: Mckoi/origsqldb
         - id: 316690542
           name: MonetDB/MonetDB
+        - id: 1183612568
+          name: NodeDB-Lab/nodedb
         - id: 684046299
           name: OpenTenBase/OpenTenBase
         - id: 41443810
@@ -240,6 +242,8 @@ data:
           name: fluree/db
         - id: 600860
           name: fosslc/Ingres
+        - id: 1127534604
+          name: garden-co/jazz
         - id: 29210020
           name: gavioto/fastdb
         - id: 95817032
@@ -362,6 +366,8 @@ data:
           name: radondb/radon
         - id: 206686299
           name: rayokota/kareldb
+        - id: 975773453
+          name: reifydb/reifydb
         - id: 393235957
           name: risinglightdb/risinglight
         - id: 453068084

--- a/labeled_data/technology/database/vector.yml
+++ b/labeled_data/technology/database/vector.yml
@@ -14,6 +14,8 @@ data:
           name: DeployQL/LintDB
         - id: 893031915
           name: HelixDB/helix-db
+        - id: 1183612568
+          name: NodeDB-Lab/nodedb
         - id: 1041584089
           name: RijinRaju/octanedb
         - id: 685897222

--- a/labeled_data/technology/database/wide_column.yml
+++ b/labeled_data/technology/database/wide_column.yml
@@ -20,6 +20,8 @@ data:
           name: StarRocks/StarRocks
         - id: 150954997
           name: VictoriaMetrics/VictoriaMetrics
+        - id: 926191450
+          name: ankur-anand/unisondb
         - id: 2524488
           name: apache/accumulo
         - id: 206424


### PR DESCRIPTION
Fix https://github.com/X-lab2017/open-digger/issues/1784

Batch label data: Incrementally add labeled repositories into the database technology.
Update Data: 
  - Update labeled data of Opensource DBMS with a github repo link based on dbdb.io and DB-Engines up to May 31, 2026. 

**Filter conditions**: 
- Collected by dbdb.io on May 31, 2026 OR Rankings in the DB-Engines Rankings table on May 31, 2026; 
- Has open source license; 
- Has repository link on GitHub; 
- The increment relative to the version https://github.com/X-lab2017/open-digger/issues/1777 on March 31, 2026 (or April 30, 2026 with no changes to the label data).

Features:
- Add 4 new repository with labels in ["Array", "Document", "Graph", "Key-value", "Relational", "Vector", "Wide column"].
  - Add 1 Array Repo: ['NodeDB-Lab/nodedb'];
  - Add 1 Document Repo: ['NodeDB-Lab/nodedb'];
  - Add 1 Graph Repo: ['NodeDB-Lab/nodedb'];
  - Add 1 Key-value Repo: ['ankur-anand/unisondb'];
  - Add 3 Relational Repo: ['NodeDB-Lab/nodedb', 'garden-co/jazz', 'reifydb/reifydb'];
  - Add 1 Vector Repo: ['NodeDB-Lab/nodedb'];
  - Add 1 Wide column Repo: ['ankur-anand/unisondb'].
 
Notes:
- The repo_id is queried from `repository_url` api `https://api.github.com/repos/{owner}/{repo}`.

