### PR TITLE
feat: add Hugging Face data gateway foundation

### DIFF
--- a/src/dataGateway/adapter.ts
+++ b/src/dataGateway/adapter.ts
@@ -1,0 +1,20 @@
+import {
+  AdapterResult,
+  DataSource,
+  EntityData,
+  EntityLocator,
+  EntityType,
+  MetricValue,
+  SearchOptions,
+  SearchResult,
+} from './types';
+
+export interface DataAdapter {
+  readonly source: DataSource;
+  readonly provider: 'opendigger' | 'opengauge';
+  readonly entityTypes: readonly EntityType[];
+
+  search(query: string, options: SearchOptions): Promise<AdapterResult<SearchResult[]>>;
+  getEntity(locator: EntityLocator): Promise<AdapterResult<EntityData> | null>;
+  getMetrics(locator: EntityLocator): Promise<AdapterResult<Record<string, MetricValue>> | null>;
+}

--- a/src/dataGateway/gateway.ts
+++ b/src/dataGateway/gateway.ts
@@ -1,0 +1,131 @@
+import { DataAdapter } from './adapter';
+import {
+  DATA_GATEWAY_SCHEMA_VERSION,
+  DataSource,
+  EntityLocator,
+  EntityResponse,
+  EntityType,
+  MetricsResponse,
+  SearchResponse,
+  SearchResult,
+  SourceDescription,
+} from './types';
+
+const DEFAULT_SEARCH_LIMIT = 20;
+const MAX_SEARCH_LIMIT = 100;
+
+export interface GatewaySearchOptions {
+  sources?: DataSource[];
+  entity_types?: EntityType[];
+  limit?: number;
+}
+
+export class DataGateway {
+  private readonly adapters = new Map<DataSource, DataAdapter>();
+  private readonly now: () => Date;
+
+  constructor(adapters: DataAdapter[], now: () => Date = () => new Date()) {
+    this.now = now;
+    for (const adapter of adapters) {
+      if (this.adapters.has(adapter.source)) {
+        throw new Error(`Duplicate data adapter for source: ${adapter.source}`);
+      }
+      this.adapters.set(adapter.source, adapter);
+    }
+  }
+
+  listSources(): SourceDescription[] {
+    return Array.from(this.adapters.values()).map(adapter => ({
+      source: adapter.source,
+      provider: adapter.provider,
+      entity_types: [...adapter.entityTypes],
+    }));
+  }
+
+  async search(query: string, options: GatewaySearchOptions = {}): Promise<SearchResponse> {
+    const normalizedQuery = query.trim();
+    if (!normalizedQuery) throw new Error('Search query must not be empty');
+
+    const limit = Math.min(Math.max(options.limit ?? DEFAULT_SEARCH_LIMIT, 1), MAX_SEARCH_LIMIT);
+    const adapters = this.selectAdapters(options.sources);
+    const settled = await Promise.allSettled(
+      adapters.map(adapter => adapter.search(normalizedQuery, {
+        entity_types: options.entity_types,
+        limit,
+      })),
+    );
+    const data: SearchResult[] = [];
+    const warnings: string[] = [];
+
+    settled.forEach((result, index) => {
+      const source = adapters[index].source;
+      if (result.status === 'rejected') {
+        warnings.push(`${source}: unavailable`);
+      } else {
+        data.push(...result.value.data);
+        warnings.push(...result.value.warnings.map(warning => `${source}: ${warning}`));
+      }
+    });
+
+    return {
+      schema_version: DATA_GATEWAY_SCHEMA_VERSION,
+      data: data.slice(0, limit),
+      meta: {
+        as_of: this.now().toISOString(),
+        partial: warnings.length > 0,
+        warnings,
+      },
+    };
+  }
+
+  async getEntity(source: DataSource, locator: EntityLocator): Promise<EntityResponse | null> {
+    const adapter = this.adapters.get(source);
+    if (!adapter) throw new Error(`Unsupported data source: ${source}`);
+    if (!adapter.entityTypes.includes(locator.entity_type)) {
+      throw new Error(`Unsupported entity type for ${source}: ${locator.entity_type}`);
+    }
+    const result = await adapter.getEntity(locator);
+    if (!result) return null;
+
+    return {
+      schema_version: DATA_GATEWAY_SCHEMA_VERSION,
+      data: result.data,
+      meta: {
+        as_of: result.as_of,
+        provider: result.provider,
+        data_quality: result.data_quality,
+        warnings: result.warnings,
+      },
+    };
+  }
+
+  async getMetrics(source: DataSource, locator: EntityLocator): Promise<MetricsResponse | null> {
+    const adapter = this.adapters.get(source);
+    if (!adapter) throw new Error(`Unsupported data source: ${source}`);
+    if (!adapter.entityTypes.includes(locator.entity_type)) {
+      throw new Error(`Unsupported entity type for ${source}: ${locator.entity_type}`);
+    }
+    const result = await adapter.getMetrics(locator);
+    if (!result) return null;
+
+    return {
+      schema_version: DATA_GATEWAY_SCHEMA_VERSION,
+      data: result.data,
+      meta: {
+        as_of: result.as_of,
+        provider: result.provider,
+        data_quality: result.data_quality,
+        warnings: result.warnings,
+      },
+    };
+  }
+
+  private selectAdapters(sources?: DataSource[]): DataAdapter[] {
+    if (!sources || sources.length === 0) return Array.from(this.adapters.values());
+    return Array.from(new Set(sources)).map(source => {
+      const adapter = this.adapters.get(source);
+      if (!adapter) throw new Error(`Unsupported data source: ${source}`);
+      return adapter;
+    });
+  }
+}

--- a/src/dataGateway/huggingFaceAdapter.ts
+++ b/src/dataGateway/huggingFaceAdapter.ts
@@ -1,0 +1,305 @@
+import { DataAdapter } from './adapter';
+import {
+  AdapterResult,
+  EntityData,
+  EntityLocator,
+  EntityType,
+  MetricSeriesPoint,
+  MetricValue,
+  SearchOptions,
+  SearchResult,
+} from './types';
+
+export type QueryParams = Record<string, string | number | boolean>;
+export type QueryExecutor = <T>(query: string, queryParams?: QueryParams) => Promise<T[]>;
+
+interface SearchRow { id: string; updated_at: string; }
+interface ModelRow {
+  id: string;
+  author: string;
+  created_at: string;
+  updated_at: string;
+  pipeline_tag: string;
+  library_name: string;
+  tags: string[];
+  gated: number | boolean;
+  disabled: number | boolean;
+}
+interface DatasetRow {
+  id: string;
+  author: string;
+  created_at: string;
+  updated_at: string;
+  tags: string[];
+  gated: number | boolean;
+  disabled: number | boolean;
+  citation: string | null;
+  description: string;
+}
+interface MetricSeedRow {
+  internal_id: string;
+  downloads: number | null;
+  likes: number | null;
+  downloads_all_time: number | null;
+  updated_at: string;
+}
+interface HistoryRow {
+  download_count: number;
+  like_count: number;
+  crawl_time: string;
+}
+
+const SUPPORTED_ENTITY_TYPES: readonly EntityType[] = ['model', 'dataset'];
+
+export class HuggingFaceAdapter implements DataAdapter {
+  readonly source = 'huggingface' as const;
+  readonly provider = 'opengauge' as const;
+  readonly entityTypes = SUPPORTED_ENTITY_TYPES;
+  private readonly query: QueryExecutor;
+  private readonly database: string;
+
+  constructor(query: QueryExecutor, database = 'huggingface_scrapy') {
+    this.query = query;
+    this.database = database;
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(database)) {
+      throw new Error(`Invalid ClickHouse database name: ${database}`);
+    }
+  }
+
+  async search(query: string, options: SearchOptions): Promise<AdapterResult<SearchResult[]>> {
+    const requestedTypes = (options.entity_types ?? [...SUPPORTED_ENTITY_TYPES])
+      .filter((entityType): entityType is 'model' | 'dataset' => SUPPORTED_ENTITY_TYPES.includes(entityType));
+    const limit = Math.min(Math.max(options.limit, 1), 100);
+    const settled = await Promise.allSettled(
+      requestedTypes.map(entityType => this.searchEntityType(entityType, query, limit)),
+    );
+    const data: SearchResult[] = [];
+    const warnings: string[] = [];
+    settled.forEach((result, index) => {
+      const entityType = requestedTypes[index];
+      if (result.status === 'rejected') warnings.push(`${entityType}: unavailable`);
+      else data.push(...result.value);
+    });
+    return {
+      data: data.slice(0, limit),
+      as_of: new Date().toISOString(),
+      provider: this.provider,
+      data_quality: [],
+      warnings,
+    };
+  }
+
+  async getEntity(locator: EntityLocator): Promise<AdapterResult<EntityData> | null> {
+    this.assertSupportedLocator(locator);
+    const entityId = `${locator.namespace}/${locator.name}`;
+    const table = locator.entity_type === 'model' ? 'model_repos' : 'dataset_repos';
+    const sourceUrl = locator.entity_type === 'model'
+      ? `https://huggingface.co/${entityId}`
+      : `https://huggingface.co/datasets/${entityId}`;
+
+    if (locator.entity_type === 'model') {
+      const rows = await this.query<ModelRow>(`
+SELECT
+  id,
+  argMax(author, lastModified) AS author,
+  min(createdAt) AS created_at,
+  max(lastModified) AS updated_at,
+  argMax(pipeline_tag, lastModified) AS pipeline_tag,
+  argMax(library_name, lastModified) AS library_name,
+  argMax(tags, lastModified) AS tags,
+  argMax(gated, lastModified) AS gated,
+  argMax(disabled, lastModified) AS disabled
+FROM ${this.database}.${table}
+WHERE id = {entityId:String}
+GROUP BY id
+HAVING argMax(private, lastModified) = 0
+LIMIT 1`, { entityId });
+      const row = rows[0];
+      if (!row) return null;
+      const metrics = await this.getMetrics(locator);
+      return this.entityResult({
+        source: this.source,
+        entity_type: 'model',
+        entity_id: row.id,
+        name: this.displayName(row.id),
+        source_url: sourceUrl,
+        attributes: {
+          author: row.author,
+          created_at: row.created_at,
+          updated_at: row.updated_at,
+          pipeline_tag: row.pipeline_tag,
+          library_name: row.library_name,
+          tags: row.tags,
+          gated: Boolean(row.gated),
+          disabled: Boolean(row.disabled),
+        },
+        metrics: metrics?.data ?? {},
+      }, metrics, row.updated_at);
+    }
+
+    const rows = await this.query<DatasetRow>(`
+SELECT
+  id,
+  argMax(author, lastModified) AS author,
+  min(createdAt) AS created_at,
+  max(lastModified) AS updated_at,
+  argMax(tags, lastModified) AS tags,
+  argMax(gated, lastModified) AS gated,
+  argMax(disabled, lastModified) AS disabled,
+  argMax(citation, lastModified) AS citation,
+  argMax(description, lastModified) AS description
+FROM ${this.database}.${table}
+WHERE id = {entityId:String}
+GROUP BY id
+HAVING argMax(private, lastModified) = 0
+LIMIT 1`, { entityId });
+    const row = rows[0];
+    if (!row) return null;
+    const metrics = await this.getMetrics(locator);
+    return this.entityResult({
+      source: this.source,
+      entity_type: 'dataset',
+      entity_id: row.id,
+      name: this.displayName(row.id),
+      source_url: sourceUrl,
+      attributes: {
+        author: row.author,
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+        tags: row.tags,
+        gated: Boolean(row.gated),
+        disabled: Boolean(row.disabled),
+        citation: row.citation,
+        description: row.description,
+      },
+      metrics: metrics?.data ?? {},
+    }, metrics, row.updated_at);
+  }
+
+  async getMetrics(locator: EntityLocator): Promise<AdapterResult<Record<string, MetricValue>> | null> {
+    this.assertSupportedLocator(locator);
+    const entityId = `${locator.namespace}/${locator.name}`;
+    const table = locator.entity_type === 'model' ? 'model_repos' : 'dataset_repos';
+    const seedRows = await this.query<MetricSeedRow>(`
+SELECT
+  argMax(_id, lastModified) AS internal_id,
+  argMax(downloads, lastModified) AS downloads,
+  argMax(likes, lastModified) AS likes,
+  argMax(downloadsAllTime, lastModified) AS downloads_all_time,
+  max(lastModified) AS updated_at
+FROM ${this.database}.${table}
+WHERE id = {entityId:String}
+HAVING argMax(private, lastModified) = 0
+LIMIT 1`, { entityId });
+    const seed = seedRows[0];
+    if (!seed || !seed.internal_id) return null;
+    const history = await this.query<HistoryRow>(`
+SELECT download_count, like_count, crawl_time
+FROM ${this.database}.dllk_history
+WHERE _id = {internalId:String}
+ORDER BY crawl_time ASC`, { internalId: seed.internal_id });
+    const latest = history[history.length - 1];
+    const observedAt = latest?.crawl_time ?? seed.updated_at;
+    const metrics: Record<string, MetricValue> = {
+      'huggingface.downloads': {
+        value: seed.downloads,
+        unit: 'downloads',
+        observed_at: seed.updated_at,
+      },
+      'huggingface.likes': {
+        value: seed.likes,
+        unit: 'likes',
+        observed_at: seed.updated_at,
+      },
+      'huggingface.downloads_all_time': {
+        value: seed.downloads_all_time,
+        unit: 'downloads',
+        observed_at: observedAt,
+      },
+      'huggingface.last_modified': {
+        value: seed.updated_at,
+        unit: null,
+        observed_at: seed.updated_at,
+      },
+    };
+    if (latest) {
+      metrics['huggingface.downloads_history'] = {
+        value: latest.download_count,
+        unit: 'downloads',
+        observed_at: latest.crawl_time,
+        series: this.series(history, 'download_count'),
+      };
+      metrics['huggingface.likes_history'] = {
+        value: latest.like_count,
+        unit: 'likes',
+        observed_at: latest.crawl_time,
+        series: this.series(history, 'like_count'),
+      };
+    }
+    return {
+      data: metrics,
+      as_of: observedAt,
+      provider: this.provider,
+      data_quality: latest ? [] : ['metric_history_missing'],
+      warnings: [],
+    };
+  }
+
+  private async searchEntityType(
+    entityType: 'model' | 'dataset',
+    query: string,
+    limit: number,
+  ): Promise<SearchResult[]> {
+    const table = entityType === 'model' ? 'model_repos' : 'dataset_repos';
+    const rows = await this.query<SearchRow>(`
+SELECT id, max(lastModified) AS updated_at
+FROM ${this.database}.${table}
+WHERE positionCaseInsensitiveUTF8(id, {query:String}) > 0
+GROUP BY id
+HAVING argMax(private, lastModified) = 0
+ORDER BY updated_at DESC
+LIMIT {limit:UInt32}`, { query, limit });
+    return rows.map(row => ({
+      source: this.source,
+      entity_type: entityType,
+      entity_id: row.id,
+      name: this.displayName(row.id),
+      source_url: entityType === 'model'
+        ? `https://huggingface.co/${row.id}`
+        : `https://huggingface.co/datasets/${row.id}`,
+    }));
+  }
+
+  private entityResult(
+    data: EntityData,
+    metrics: AdapterResult<Record<string, MetricValue>> | null,
+    fallbackAsOf: string,
+  ): AdapterResult<EntityData> {
+    return {
+      data,
+      as_of: metrics?.as_of ?? fallbackAsOf,
+      provider: this.provider,
+      data_quality: metrics?.data_quality ?? ['metric_history_missing'],
+      warnings: metrics?.warnings ?? [],
+    };
+  }
+
+  private assertSupportedLocator(locator: EntityLocator): asserts locator is EntityLocator & {
+    entity_type: 'model' | 'dataset';
+  } {
+    if (!SUPPORTED_ENTITY_TYPES.includes(locator.entity_type)) {
+      throw new Error(`Unsupported Hugging Face entity type: ${locator.entity_type}`);
+    }
+    if (!locator.namespace.trim() || !locator.name.trim()) {
+      throw new Error('Hugging Face namespace and name must not be empty');
+    }
+  }
+
+  private displayName(entityId: string): string {
+    return entityId.split('/').pop() ?? entityId;
+  }
+
+  private series(history: HistoryRow[], key: 'download_count' | 'like_count'): MetricSeriesPoint[] {
+    return history.map(row => ({ time: row.crawl_time, value: row[key] }));
+  }
+}

--- a/src/dataGateway/index.ts
+++ b/src/dataGateway/index.ts
@@ -1,0 +1,4 @@
+export * from './adapter';
+export * from './gateway';
+export * from './huggingFaceAdapter';
+export * from './types';

--- a/src/dataGateway/types.ts
+++ b/src/dataGateway/types.ts
@@ -1,0 +1,88 @@
+export const DATA_GATEWAY_SCHEMA_VERSION = '1.0' as const;
+
+export type DataSource = 'github' | 'huggingface';
+export type EntityType = 'repository' | 'model' | 'dataset' | 'account' | 'organization';
+
+export interface MetricSeriesPoint {
+  time: string;
+  value: number | null;
+}
+
+export interface MetricValue {
+  value: number | string | boolean | null;
+  unit?: string | null;
+  observed_at: string;
+  series?: MetricSeriesPoint[];
+}
+
+export interface EntityData {
+  source: DataSource;
+  entity_type: EntityType;
+  entity_id: string;
+  name: string;
+  source_url: string;
+  attributes: Record<string, unknown>;
+  metrics: Record<string, MetricValue>;
+}
+
+export interface ResponseMeta {
+  as_of: string;
+  provider: 'opendigger' | 'opengauge';
+  data_quality: string[];
+  warnings: string[];
+}
+
+export interface EntityResponse {
+  schema_version: typeof DATA_GATEWAY_SCHEMA_VERSION;
+  data: EntityData;
+  meta: ResponseMeta;
+}
+
+export interface SearchResult {
+  source: DataSource;
+  entity_type: EntityType;
+  entity_id: string;
+  name: string;
+  source_url: string;
+}
+
+export interface SearchResponse {
+  schema_version: typeof DATA_GATEWAY_SCHEMA_VERSION;
+  data: SearchResult[];
+  meta: {
+    as_of: string;
+    partial: boolean;
+    warnings: string[];
+  };
+}
+
+export interface MetricsResponse {
+  schema_version: typeof DATA_GATEWAY_SCHEMA_VERSION;
+  data: Record<string, MetricValue>;
+  meta: ResponseMeta;
+}
+
+export interface AdapterResult<T> {
+  data: T;
+  as_of: string;
+  provider: ResponseMeta['provider'];
+  data_quality: string[];
+  warnings: string[];
+}
+
+export interface EntityLocator {
+  entity_type: EntityType;
+  namespace: string;
+  name: string;
+}
+
+export interface SearchOptions {
+  entity_types?: EntityType[];
+  limit: number;
+}
+
+export interface SourceDescription {
+  source: DataSource;
+  provider: ResponseMeta['provider'];
+  entity_types: EntityType[];
+}

--- a/test/dataGateway.test.ts
+++ b/test/dataGateway.test.ts
@@ -1,0 +1,193 @@
+import assert from 'assert';
+import { DataAdapter } from '../src/dataGateway/adapter';
+import { DataGateway } from '../src/dataGateway/gateway';
+import { HuggingFaceAdapter, QueryExecutor, QueryParams } from '../src/dataGateway/huggingFaceAdapter';
+import {
+  AdapterResult,
+  EntityData,
+  EntityLocator,
+  MetricValue,
+  SearchOptions,
+  SearchResult,
+} from '../src/dataGateway/types';
+
+class FakeAdapter implements DataAdapter {
+  readonly entityTypes = ['repository'] as const;
+  readonly source: 'github';
+  readonly provider: 'opendigger';
+  private readonly shouldFail: boolean;
+
+  constructor(
+    source: 'github',
+    provider: 'opendigger',
+    shouldFail = false,
+  ) {
+    this.source = source;
+    this.provider = provider;
+    this.shouldFail = shouldFail;
+  }
+
+  async search(query: string, _options: SearchOptions): Promise<AdapterResult<SearchResult[]>> {
+    if (this.shouldFail) throw new Error('offline');
+    return {
+      data: [{
+        source: this.source,
+        entity_type: 'repository',
+        entity_id: `example/${query}`,
+        name: query,
+        source_url: `https://github.com/example/${query}`,
+      }],
+      as_of: '2026-07-22T00:00:00.000Z',
+      provider: this.provider,
+      data_quality: [],
+      warnings: [],
+    };
+  }
+
+  async getEntity(_locator: EntityLocator): Promise<AdapterResult<EntityData> | null> { return null; }
+  async getMetrics(_locator: EntityLocator): Promise<AdapterResult<Record<string, MetricValue>> | null> { return null; }
+}
+
+describe('DataGateway', () => {
+  it('combines adapters behind one search response', async () => {
+    const github = new FakeAdapter('github', 'opendigger');
+    const huggingface = new HuggingFaceAdapter(async <T>(sql: string) => {
+      if (sql.includes('model_repos')) {
+        return [{ id: 'Qwen/Qwen3-8B', updated_at: '2026-07-22T00:00:00.000Z' }] as T[];
+      }
+      return [];
+    });
+    const gateway = new DataGateway(
+      [github, huggingface],
+      () => new Date('2026-07-22T01:00:00.000Z'),
+    );
+    const result = await gateway.search('qwen');
+    assert.strictEqual(result.schema_version, '1.0');
+    assert.deepStrictEqual(result.data.map(item => item.source), ['github', 'huggingface']);
+    assert.strictEqual(result.meta.partial, false);
+    assert.strictEqual(result.meta.as_of, '2026-07-22T01:00:00.000Z');
+  });
+
+  it('returns partial results when one source is unavailable', async () => {
+    const gateway = new DataGateway([
+      new FakeAdapter('github', 'opendigger', true),
+      new HuggingFaceAdapter(async <T>(sql: string) => {
+        if (sql.includes('model_repos')) {
+          return [{ id: 'Qwen/Qwen3-8B', updated_at: '2026-07-22T00:00:00.000Z' }] as T[];
+        }
+        return [];
+      }),
+    ]);
+    const result = await gateway.search('qwen');
+    assert.strictEqual(result.meta.partial, true);
+    assert.deepStrictEqual(result.meta.warnings, ['github: unavailable']);
+    assert.strictEqual(result.data.length, 1);
+    assert.strictEqual(result.data[0].source, 'huggingface');
+  });
+
+  it('rejects unsupported sources instead of falling through', async () => {
+    const gateway = new DataGateway([]);
+    await assert.rejects(
+      gateway.search('qwen', { sources: ['github'] }),
+      /Unsupported data source: github/,
+    );
+  });
+
+  it('routes metric reads through the selected adapter', async () => {
+    const huggingface = new HuggingFaceAdapter(async <T>(sql: string) => {
+      if (sql.includes('AS downloads_all_time')) {
+        return [{ internal_id: 'hf-id', downloads: 7, likes: 2, downloads_all_time: 20,
+          updated_at: '2026-07-22T00:00:00.000Z' }] as T[];
+      }
+      return [];
+    });
+    const gateway = new DataGateway([huggingface]);
+    const result = await gateway.getMetrics('huggingface', {
+      entity_type: 'model', namespace: 'example', name: 'model',
+    });
+    assert(result);
+    assert.strictEqual(result.schema_version, '1.0');
+    assert.strictEqual(result.data['huggingface.downloads'].value, 7);
+    assert.strictEqual(result.meta.provider, 'opengauge');
+  });
+});
+
+describe('HuggingFaceAdapter', () => {
+  it('uses query parameters for search and excludes private entities', async () => {
+    const calls: { sql: string, params: Record<string, unknown> }[] = [];
+    const query: QueryExecutor = async <T>(sql: string, params: QueryParams = {}) => {
+      calls.push({ sql, params });
+      if (sql.includes('model_repos')) {
+        return [{ id: 'Qwen/Qwen3-8B', updated_at: '2026-07-22T00:00:00.000Z' }] as T[];
+      }
+      return [];
+    };
+    const adapter = new HuggingFaceAdapter(query);
+    const result = await adapter.search("qwen' OR 1=1", { entity_types: ['model'], limit: 500 });
+    assert.strictEqual(result.data.length, 1);
+    assert.strictEqual(calls[0].params.query, "qwen' OR 1=1");
+    assert.strictEqual(calls[0].params.limit, 100);
+    assert(!calls[0].sql.includes("qwen' OR 1=1"));
+    assert(calls[0].sql.includes('HAVING argMax(private, lastModified) = 0'));
+  });
+
+  it('maps a model and its history to the unified entity response', async () => {
+    const calls: { sql: string, params: Record<string, unknown> }[] = [];
+    const query: QueryExecutor = async <T>(sql: string, params: QueryParams = {}) => {
+      calls.push({ sql, params });
+      if (sql.includes('AS author')) {
+        return [{
+          id: 'Qwen/Qwen3-8B', author: 'Qwen',
+          created_at: '2026-07-01T00:00:00.000Z', updated_at: '2026-07-20T00:00:00.000Z',
+          pipeline_tag: 'text-generation', library_name: 'transformers', tags: ['transformers'],
+          gated: 0, disabled: 0,
+        }] as T[];
+      }
+      if (sql.includes('AS downloads_all_time')) {
+        return [{ internal_id: 'hf-internal-id', downloads: 150, likes: 12, downloads_all_time: 1200,
+          updated_at: '2026-07-20T00:00:00.000Z' }] as T[];
+      }
+      if (sql.includes('dllk_history')) {
+        return [
+          { download_count: 100, like_count: 10, crawl_time: '2026-07-20T00:00:00.000Z' },
+          { download_count: 150, like_count: 12, crawl_time: '2026-07-21T00:00:00.000Z' },
+        ] as T[];
+      }
+      return [];
+    };
+    const gateway = new DataGateway([new HuggingFaceAdapter(query)]);
+    const result = await gateway.getEntity('huggingface', {
+      entity_type: 'model', namespace: 'Qwen', name: 'Qwen3-8B',
+    });
+    assert(result);
+    assert.strictEqual(result.schema_version, '1.0');
+    assert.strictEqual(result.data.entity_id, 'Qwen/Qwen3-8B');
+    assert.strictEqual(result.data.attributes.pipeline_tag, 'text-generation');
+    assert.strictEqual(result.data.metrics['huggingface.downloads'].value, 150);
+    assert.strictEqual(result.data.metrics['huggingface.downloads_history'].series?.length, 2);
+    assert.strictEqual(result.meta.as_of, '2026-07-21T00:00:00.000Z');
+    const historyCall = calls.find(call => call.sql.includes('dllk_history'));
+    assert(historyCall);
+    assert.strictEqual(historyCall.params.internalId, 'hf-internal-id');
+  });
+
+  it('queries history by internal id and marks missing history', async () => {
+    const query: QueryExecutor = async <T>(sql: string, params: QueryParams = {}) => {
+      if (sql.includes('AS downloads_all_time')) {
+        return [{ internal_id: 'dataset-internal-id', downloads: 3, likes: 1, downloads_all_time: 10,
+          updated_at: '2026-07-20T00:00:00.000Z' }] as T[];
+      }
+      if (sql.includes('dllk_history')) {
+        assert.strictEqual(params.internalId, 'dataset-internal-id');
+        assert.strictEqual(params.entityId, undefined);
+      }
+      return [];
+    };
+    const adapter = new HuggingFaceAdapter(query);
+    const result = await adapter.getMetrics({
+      entity_type: 'dataset', namespace: 'example', name: 'data',
+    });
+    assert(result);
+    assert.deepStrictEqual(result.data_quality, ['metric_history_missing']);
+  });
+});


### PR DESCRIPTION
Relates to #1790.

## Summary

- add a versioned cross-source Data Gateway contract;
- add a small adapter interface and Gateway orchestration;
- add a Hugging Face adapter for model/dataset search, profiles, current metrics, and history;
- return partial search results when one source is unavailable;
- add focused unit tests for routing, mapping, query safety, private-data filtering, and missing history.

## Design boundaries

- OpenDigger remains the unified platform;
- OpenGauge remains an independent Hugging Face data provider;
- no database migration, cross-database JOIN, collector merge, HTTP server, or MCP change in this PR;
- database access is injected and expected to use a dedicated read-only account;
- no credentials, connection URLs, or internal network details are included.

## Local validation

- full TypeScript project compilation passed;
- Data Gateway unit tests: 7 passing;
- git diff whitespace check passed;
- sensitive-value scan of added files passed.

## Follow-ups after maintainers confirm the direction

- select the stable OpenDigger data source for GitHubAdapter;
- decide whether the deployable HTTP layer belongs here or in a service repository;
- expose the accepted contract through HTTP and OpenDigger MCP.