### PR TITLE
label: Update database labeled data for July 2026.

### DIFF
--- a/labeled_data/technology/database/array.yml
+++ b/labeled_data/technology/database/array.yml
@@ -10,6 +10,8 @@ data:
           name: EuclidOLAP/EuclidOLAP
         - id: 1183612568
           name: NodeDB-Lab/nodedb
+        - id: 1211040071
+          name: NumstoreDB/Numstore
         - id: 86868560
           name: TileDB-Inc/TileDB
         - id: 31373521
@@ -18,6 +20,8 @@ data:
           name: datajaguar/jaguardb
         - id: 664133375
           name: epsilla-cloud/vectordb
+        - id: 1208697458
+          name: hexxla/hexxladb
         - id: 45732002
           name: jnidzwetzki/bboxdb
         - id: 489656726

--- a/labeled_data/technology/database/document.yml
+++ b/labeled_data/technology/database/document.yml
@@ -34,38 +34,54 @@ data:
           name: ArcadeData/arcadedb
         - id: 1374129
           name: BaseXdb/basex
+        - id: 234091935
+          name: DO-SAY-GO/sirdb
         - id: 8799170
           name: DevrexLabs/OrigoDB
+        - id: 1234582852
+          name: ExtendDB/extenddb
         - id: 422821402
           name: FerretDB/FerretDB
         - id: 605189726
           name: FgForrest/evitaDB
         - id: 404610048
           name: Fl1yd/LightDB
-        - id: 8313554
-          name: Greg0/Lazer-Database
         - id: 10296238
           name: HouzuoGuo/tiedot
         - id: 19271154
           name: JetBrains/xodus
         - id: 31315021
           name: Kinto/kinto
+        - id: 8313554
+          name: Lazer-Database/Lazer-Database
         - id: 533032
           name: LinkedInAttic/sensei
         - id: 750864017
           name: Lona-Development/Server
+        - id: 1111440285
+          name: MauricioPerera/LOKIVECTOR
         - id: 50098469
           name: Nexedi/neoppod
         - id: 1183612568
           name: NodeDB-Lab/nodedb
         - id: 284225188
           name: PoloDB/PoloDB
+        - id: 836018246
+          name: Schema-JS/schema-js
         - id: 188354257
           name: SequoiaDB/SequoiaDB
+        - id: 129436009
+          name: SleekDB/SleekDB
         - id: 474070793
           name: SnellerInc/sneller
         - id: 6427744
           name: Softmotions/ejdb
+        - id: 8729689
+          name: Tokutek/mongo
+        - id: 813243891
+          name: Unconcurrent/SoloDB
+        - id: 1182378589
+          name: VincentKaufmann/GitDB
         - id: 8428443
           name: X2rdas/easedb
         - id: 124315604
@@ -76,10 +92,16 @@ data:
           name: apache/couchdb
         - id: 5683653
           name: apache/drill
+        - id: 223462217
+          name: apache/incubator-resilientdb
         - id: 341631350
           name: apache/lucene
         - id: 50229487
           name: apache/lucene-solr
+        - id: 714074
+          name: apache/pouchdb
+        - id: 341374920
+          name: apache/solr
         - id: 114187903
           name: apple/foundationdb
         - id: 137869753
@@ -90,8 +112,12 @@ data:
           name: ashfromsky/yaradb
         - id: 36778364
           name: attic-labs/noms
+        - id: 249981301
+          name: aviondb/aviondb
         - id: 642912355
           name: awa-ai/awadb
+        - id: 1296163320
+          name: barrel-db/barrel
         - id: 141378316
           name: beardedeagle/mnesiac
         - id: 88422672
@@ -100,16 +126,16 @@ data:
           name: berkeleydb/libdb
         - id: 51290852
           name: bigchaindb/bigchaindb
-        - id: 57401138
-          name: bitnine-oss/agensgraph
+        - id: 18893367
+          name: blevesearch/bleve
         - id: 127338417
           name: bluzi/jsonstore
-        - id: 234091935
-          name: c9fe/sirdb
         - id: 844591313
           name: capjamesg/jamesql
         - id: 639434928
           name: cfu288/SylvieJS
+        - id: 138411034
+          name: chaisql/chai
         - id: 546206616
           name: chroma-core/chroma
         - id: 13353426
@@ -120,12 +146,14 @@ data:
           name: crate/crate
         - id: 722117815
           name: cursusdb/cursusdb
-        - id: 249981301
-          name: dappkit/aviondb
+        - id: 270858421
+          name: datalevin/datalevin
         - id: 4732384
           name: dcramer/mangodb
         - id: 88777477
           name: dizitart/nitrite-database
+        - id: 920805662
+          name: documentdb/documentdb
         - id: 17684716
           name: dsukhoroslov/bagri
         - id: 11695619
@@ -144,8 +172,6 @@ data:
           name: fireproof-storage/fireproof
         - id: 305513242
           name: fluree/db
-        - id: 138411034
-          name: genjidb/genji
         - id: 897888926
           name: goatplatform/goatdb
         - id: 852516379
@@ -158,8 +184,12 @@ data:
           name: hhblaze/DBreeze
         - id: 50836580
           name: iboxdb/ftserver
+        - id: 1171244520
+          name: inder/salvobase
         - id: 4984118
           name: ioquatix/relaxo
+        - id: 25364889
+          name: jbasiglio/fueldb
         - id: 58524063
           name: jclo/picodb
         - id: 4859
@@ -172,18 +202,22 @@ data:
           name: jina-ai/vectordb
         - id: 811062736
           name: joswayski/averagedatabase
-        - id: 270858421
-          name: juji-io/datalevin
         - id: 632269609
           name: kagisearch/vectordb
+        - id: 1230283259
+          name: katehonz/barabaDB
         - id: 1776883
           name: kimchy/compass
         - id: 622856821
           name: kronotop/kronotop
+        - id: 5844474
+          name: kurrent-io/KurrentDB
         - id: 607441698
           name: lancedb/lancedb
         - id: 349172057
           name: linkedin/venice
+        - id: 23315232
+          name: litedb-org/LiteDB
         - id: 376679845
           name: losfair/RefineDB
         - id: 9795883
@@ -192,8 +226,6 @@ data:
           name: marqo-ai/marqo
         - id: 661663226
           name: maxnowack/signaldb
-        - id: 23315232
-          name: mbdavid/LiteDB
         - id: 130688011
           name: meilisearch/meilisearch
         - id: 26573806
@@ -208,14 +240,18 @@ data:
           name: msiemens/tinydb
         - id: 5912693
           name: ncannasse/castle
+        - id: 47479424
+          name: nucypher/zerodb
         - id: 33053071
           name: oberasoftware/jasdb
         - id: 3788366
           name: openlink/virtuoso-opensource
+        - id: 334274271
+          name: opensearch-project/OpenSearch
         - id: 298920362
           name: oracle/nosql-java-sdk
         - id: 48617634
-          name: orbitdb/orbit-db
+          name: orbitdb/orbitdb
         - id: 7083240
           name: orientechnologies/orientdb
         - id: 453191009
@@ -228,8 +264,6 @@ data:
           name: percona/percona-server-mongodb
         - id: 166387176
           name: polypheny/Polypheny-DB
-        - id: 714074
-          name: pouchdb/pouchdb
         - id: 5349565
           name: prestodb/presto
         - id: 10153163
@@ -243,15 +277,11 @@ data:
         - id: 49412556
           name: quickwit-oss/tantivy
         - id: 5665061
-          name: radare/sdb
-        - id: 129436009
-          name: rakibtg/SleekDB
+          name: radareorg/sdb
         - id: 542714
           name: ravendb/ravendb
         - id: 1917262
           name: realm/realm-core
-        - id: 223462217
-          name: resilientdb/resilientdb
         - id: 6452529
           name: rethinkdb/rethinkdb
         - id: 336867666
@@ -259,19 +289,23 @@ data:
         - id: 34056205
           name: sachin-sinha/BangDB
         - id: 664816265
-          name: scratchdata/ScratchDB
+          name: scratchdata/scratchdata
         - id: 5841618
           name: sedna/sedna
         - id: 9525219
           name: sergeyksv/tingodb
         - id: 4604367
           name: sirixdb/sirix
+        - id: 57401138
+          name: skaiworldwide-oss/agensgraph
         - id: 295745510
           name: small-tech/jsdb
         - id: 1087408719
           name: sohzm/jasonisnthappy
         - id: 192631273
           name: sourcenetwork/defradb
+        - id: 36992044
+          name: sphinxsearch/sphinx
         - id: 436658287
           name: surrealdb/surrealdb
         - id: 22761491
@@ -298,8 +332,6 @@ data:
           name: typicaljoe/taffydb
         - id: 18351848
           name: typicode/lowdb
-        - id: 25364889
-          name: unnamed38/fueldb
         - id: 186332888
           name: vearch/vearch
         - id: 634656527
@@ -312,7 +344,5 @@ data:
           name: xtdb/xtdb
         - id: 456549280
           name: ydb-platform/ydb
-        - id: 574588439
-          name: ytsaurus/ytsaurus
-        - id: 47479424
-          name: zerodb/zerodb
+        - id: 1242559745
+          name: zaydmulani09/vecdb

--- a/labeled_data/technology/database/graph.yml
+++ b/labeled_data/technology/database/graph.yml
@@ -16,10 +16,16 @@ data:
           name: CulturePlex/Sylva
         - id: 8799170
           name: DevrexLabs/OrigoDB
+        - id: 1096820313
+          name: GraphLite-AI/GraphLite
         - id: 893031915
           name: HelixDB/helix-db
+        - id: 1244916331
+          name: IssunDB/issun-db
         - id: 77385607
           name: JanusGraph/janusgraph
+        - id: 759929648
+          name: JetBrains/youtrackdb
         - id: 1071734040
           name: LadybugDB/ladybug
         - id: 1183612568
@@ -36,20 +42,26 @@ data:
           name: SparsityTechnologies/sparksee-server
         - id: 528766495
           name: TuGraph-family/tugraph-db
+        - id: 27594187
+          name: ad-freiburg/qlever
+        - id: 1170374747
+          name: alibaba/neug
         - id: 22475123
           name: amark/gun
+        - id: 1182753977
+          name: antflydb/antfly
         - id: 276293034
           name: apache/age
         - id: 2282376
           name: apache/giraph
         - id: 141376301
-          name: apache/incubator-hugegraph
+          name: apache/hugegraph
         - id: 30449481
           name: apache/tinkerpop
         - id: 2649214
           name: arangodb/arangodb
-        - id: 57401138
-          name: bitnine-oss/agensgraph
+        - id: 1237465314
+          name: ayoubnabil/aiondb
         - id: 48451041
           name: blazegraph/database
         - id: 511030127
@@ -62,6 +74,8 @@ data:
           name: dgraph-io/dgraph
         - id: 402209532
           name: dyedgreen/cqlite
+        - id: 590923204
+          name: estebanrfp/gdb
         - id: 668673665
           name: falkordb/falkordb
         - id: 74678263
@@ -76,6 +90,8 @@ data:
           name: hypergraphdb/hypergraphdb
         - id: 166429903
           name: jssmith/stigdb
+        - id: 1230283259
+          name: katehonz/barabaDB
         - id: 65619619
           name: krotik/eliasdb
         - id: 298763623
@@ -86,12 +102,18 @@ data:
           name: memgraph/memgraph
         - id: 81411018
           name: microsoft/GraphEngine
+        - id: 1201033913
+          name: nambok/mentedb
+        - id: 1242792159
+          name: namidb/namidb
         - id: 6650539
           name: neo4j/neo4j
         - id: 7083240
           name: orientechnologies/orientdb
         - id: 1111263109
           name: orneryd/NornicDB
+        - id: 133687025
+          name: oxigraph/oxigraph
         - id: 26917250
           name: pkumod/gStore
         - id: 166387176
@@ -104,6 +126,12 @@ data:
           name: rayokota/hgraphdb
         - id: 1051002990
           name: sanonone/kektordb
+        - id: 57401138
+          name: skaiworldwide-oss/agensgraph
+        - id: 1126115972
+          name: sochdb/sochdb
+        - id: 1169046116
+          name: softmaxdata/engram
         - id: 743502
           name: sones/sones
         - id: 55578752
@@ -122,5 +150,5 @@ data:
           name: typedb/typedb
         - id: 146459443
           name: vesoft-inc/nebula
-        - id: 759929648
-          name: youtrackdb/youtrackdb
+        - id: 1164482810
+          name: yantrikos/yantrikdb

--- a/labeled_data/technology/database/hierarchical.yml
+++ b/labeled_data/technology/database/hierarchical.yml
@@ -10,3 +10,5 @@ data:
           name: apache/iotdb
         - id: 160999
           name: apache/zookeeper
+        - id: 1128123594
+          name: volcengine/OpenViking

--- a/labeled_data/technology/database/key_value.yml
+++ b/labeled_data/technology/database/key_value.yml
@@ -22,6 +22,8 @@ data:
     - name: GitHub
       type: Code Hosting
       repos:
+        - id: 981319788
+          name: 539hex/zu
         - id: 28956774
           name: Alachisoft/NCache
         - id: 28457976
@@ -40,14 +42,16 @@ data:
           name: BohuTANG/nessDB
         - id: 8799170
           name: DevrexLabs/OrigoDB
+        - id: 1234582852
+          name: ExtendDB/extenddb
+        - id: 1199943658
+          name: GNS-Foundation/mobydb
         - id: 840308148
           name: Gifted-s/velarixdb
         - id: 344711168
           name: IceFireDB/IceFireDB
         - id: 3019304
           name: Incubaid/arakoon
-        - id: 202483348
-          name: KvrocksLabs/kvrocks
         - id: 34406933
           name: LMDB/lmdb
         - id: 259542436
@@ -58,14 +62,16 @@ data:
           name: Nanolat/nldb
         - id: 8103021
           name: Netflix/EVCache
+        - id: 13484625
+          name: Netflix/dynomite
+        - id: 26127968
+          name: OpenAtomFoundation/pikiwidb
         - id: 21985130
           name: OpenHFT/Chronicle-Map
         - id: 865412
           name: OpenTSDB/opentsdb
         - id: 80648455
           name: PumpkinDB/PumpkinDB
-        - id: 26127968
-          name: Qihoo360/pika
         - id: 18409684
           name: RichardHightower/slumberdb
         - id: 31363586
@@ -76,8 +82,12 @@ data:
           name: Softmotions/ejdb
         - id: 64182745
           name: SparrowDb/sparrowdb
+        - id: 149111813
+          name: Tencent/MMKV
         - id: 321853986
           name: Tencent/Tendis
+        - id: 415886839
+          name: TieredMemDB/TieredMemDB
         - id: 13677899
           name: Treode/store
         - id: 180245584
@@ -92,12 +102,16 @@ data:
           name: alash3al/redix
         - id: 926191450
           name: ankur-anand/unisondb
+        - id: 1034637202
+          name: antithesishq/valthree
         - id: 206424
           name: apache/cassandra
         - id: 34839383
           name: apache/geode
         - id: 31006158
           name: apache/ignite
+        - id: 202483348
+          name: apache/kvrocks
         - id: 28738447
           name: apache/kylin
         - id: 114187903
@@ -108,8 +122,8 @@ data:
           name: armink/FlashDB
         - id: 457763204
           name: avinassh/py-caskdb
-        - id: 6768410
-          name: badgerman/ennodb
+        - id: 632037
+          name: basho/bitcask
         - id: 613723
           name: basho/riak
         - id: 791522
@@ -120,8 +134,6 @@ data:
           name: berkeleydb/libdb
         - id: 51290852
           name: bigchaindb/bigchaindb
-        - id: 57401138
-          name: bitnine-oss/agensgraph
         - id: 15345331
           name: boltdb/bolt
         - id: 320459354
@@ -136,6 +148,8 @@ data:
           name: chromodb/chromodb
         - id: 26826806
           name: cloudflarearchive/kyotocabinet
+        - id: 141339868
+          name: cockroachdb/pebble
         - id: 220186120
           name: codenotary/immudb
         - id: 69400326
@@ -157,15 +171,21 @@ data:
         - id: 80087836
           name: dgraph-io/badger
         - id: 531220682
-          name: dicedb/dice
+          name: dicedb/dicedb
+        - id: 3115025
+          name: dlitz/resin
         - id: 789424265
           name: dmarro89/dare-db
         - id: 437245741
           name: dragonflydb/dragonfly
+        - id: 722854801
+          name: edwinkys/oasysdb
         - id: 17224514
           name: ehcache/ehcache3
         - id: 393005910
           name: engula/engula
+        - id: 6768410
+          name: ennorehling/ennodb
         - id: 44061596
           name: erthink/libmdbx
         - id: 278320002
@@ -200,18 +220,20 @@ data:
           name: gruns/ImmortalDB
         - id: 2272541
           name: gstrauss/mcdb
+        - id: 879526764
+          name: guycipher/k4
         - id: 3786237
           name: hazelcast/hazelcast
         - id: 12050336
           name: hhblaze/DBreeze
         - id: 1202421
           name: hibari/hibari
-        - id: 195895847
-          name: hivedb/hive
         - id: 274184952
           name: hoytech/quadrable
         - id: 3502280
           name: hthetiot/Tokyo-Tyrant
+        - id: 952556108
+          name: hydraide/hydraide
         - id: 7561862
           name: ideawu/ssdb
         - id: 1050944
@@ -220,6 +242,8 @@ data:
           name: infoforcefeed/OlegDB
         - id: 31342455
           name: iondbproject/iondb
+        - id: 195895847
+          name: isar/hive
         - id: 265390281
           name: jakekgrog/GhostDB
         - id: 5453989
@@ -230,18 +254,26 @@ data:
           name: jingwei/krati
         - id: 37932930
           name: justin-db/JustinDB
+        - id: 8039659
+          name: kairosdb/kairosdb
         - id: 191442206
           name: kashirin-alex/swc-db
         - id: 349627612
           name: khonsulabs/bonsaidb
         - id: 3102187
           name: krestenkrab/hanoidb
+        - id: 328647920
+          name: leanstore/leanstore
         - id: 19296225
           name: ledisdb/ledisdb
         - id: 38254684
           name: linkedin/PalDB
+        - id: 1198485229
+          name: lispking/kvdb
         - id: 323389945
           name: logicalclocks/rondb
+        - id: 438128602
+          name: lotusdblabs/lotusdb
         - id: 1066389431
           name: mailmug/zentropy
         - id: 62980788
@@ -266,32 +298,36 @@ data:
           name: nathanmarz/elephantdb
         - id: 149145424
           name: nextgres/oss-haildb
-        - id: 722854801
-          name: oasysai/oasysdb
+        - id: 858384155
+          name: nubskr/nubmq
+        - id: 160784930
+          name: nutsdb/nutsdb
         - id: 4211523
           name: oleiade/Elevator
         - id: 12106192
           name: oleiade/trousseau
-        - id: 242776849
-          name: oracle/coherence
         - id: 298920362
           name: oracle/nosql-java-sdk
         - id: 48617634
-          name: orbitdb/orbit-db
+          name: orbitdb/orbitdb
         - id: 7083240
           name: orientechnologies/orientdb
+        - id: 891723751
+          name: outr/HaloDB
+        - id: 454981666
+          name: oxia-db/oxia
         - id: 606125384
           name: paypal/junodb
         - id: 6714651
           name: perchouli/codernitydb
-        - id: 278684767
-          name: petermattis/pebble
         - id: 502268740
           name: photondb/photondb
         - id: 37285717
           name: pilgr/Paper
         - id: 41986369
           name: pingcap/tidb
+        - id: 12843155
+          name: pmwkaa/sophia
         - id: 5349565
           name: prestodb/presto
         - id: 385283362
@@ -300,6 +336,8 @@ data:
           name: prometheus/prometheus
         - id: 542714
           name: ravendb/ravendb
+        - id: 10081109
+          name: rax-maas/blueflood
         - id: 156018
           name: redis/redis
         - id: 441299511
@@ -308,6 +346,8 @@ data:
           name: redwood/redwood
         - id: 494545073
           name: reesporte/bugfruit
+        - id: 116407410
+          name: replikativ/datahike
         - id: 76373812
           name: rescrv/Consus
         - id: 3493103
@@ -321,7 +361,7 @@ data:
         - id: 345739
           name: roma/roma
         - id: 318972528
-          name: roseduan/rosedb
+          name: rosedblabs/rosedb
         - id: 779811016
           name: sabledb-io/sabledb
         - id: 34056205
@@ -333,11 +373,15 @@ data:
         - id: 715589
           name: scalien/scaliendb
         - id: 28449431
-          name: scylladb/scylla
+          name: scylladb/scylladb
         - id: 1499938
           name: shino/kai
         - id: 121126549
           name: simerplaha/SwayDB
+        - id: 57401138
+          name: skaiworldwide-oss/agensgraph
+        - id: 942380667
+          name: sklad-dev/Sklad
         - id: 276042304
           name: skytable/skytable
         - id: 777912773
@@ -348,22 +392,28 @@ data:
           name: speedb-io/speedb
         - id: 36483902
           name: spotify/heroic
+        - id: 12488811
+          name: spotify/sparkey
         - id: 919276446
           name: starskey-io/starskey
         - id: 34593732
           name: stephenmcd/curiodb
-        - id: 454981666
-          name: streamnative/oxia
+        - id: 580788054
+          name: storacha/pail
         - id: 26888631
-          name: stripe/sequins
+          name: stripe-archive/sequins
         - id: 421444565
           name: surrealdb/echodb
         - id: 22761491
           name: symisc/unqlite
         - id: 911980
           name: tarantool/tarantool
+        - id: 426652249
+          name: thetarby/helindb
         - id: 63731386
           name: tidwall/buntdb
+        - id: 1023788092
+          name: tidwall/pogocache
         - id: 64404140
           name: tidwall/redcon
         - id: 70629059
@@ -392,22 +442,20 @@ data:
           name: voidDB/voidDB
         - id: 214605
           name: voldemort/voldemort
-        - id: 580788054
-          name: web3-storage/pail
         - id: 30828379
           name: willemt/pearldb
         - id: 2944302
           name: wiredtiger/wiredtiger
-        - id: 65259211
-          name: xap/xap
         - id: 20433978
           name: xtreemfs/babudb
-        - id: 160784930
-          name: xujiajun/nutsdb
         - id: 137792810
           name: yahoo/HaloDB
+        - id: 1164482810
+          name: yantrikos/yantrikdb
         - id: 9048279
           name: yinqiwen/ardb
+        - id: 574588439
+          name: ytsaurus/ytsaurus
         - id: 105944401
           name: yugabyte/yugabyte-db
         - id: 7357595

--- a/labeled_data/technology/database/object_oriented.yml
+++ b/labeled_data/technology/database/object_oriented.yml
@@ -9,20 +9,18 @@ data:
     - name: GitHub
       type: Code Hosting
       repos:
-        - id: 107504377
-          name: ADBSQL/AntDB
         - id: 37905036
           name: Alachisoft/TayzGrid
+        - id: 396867188
+          name: ArcadeData/arcadedb
         - id: 681142
           name: Bobris/BTDB
-        - id: 52080367
-          name: CUBRID/cubrid
         - id: 329729926
           name: CondensationDB/Condensation-java
         - id: 8799170
           name: DevrexLabs/OrigoDB
-        - id: 516821813
-          name: HydrasDB/hydra
+        - id: 366298992
+          name: Log2n-io/Typhon
         - id: 1244027
           name: ModeShape/modeshape
         - id: 1040715058
@@ -39,12 +37,8 @@ data:
           name: apache/jackrabbit
         - id: 246343828
           name: atoti/atoti
-        - id: 40787594
-          name: aur-archive/gigabase
         - id: 396856161
           name: authzed/spicedb
-        - id: 644742603
-          name: cloudberrydb/cloudberrydb
         - id: 95070401
           name: devrexlabs/memstate
         - id: 15001136
@@ -55,8 +49,8 @@ data:
           name: fern4lvarez/piladb
         - id: 240387847
           name: gaia-platform/GaiaPlatform
-        - id: 95817032
-          name: geldata/gel
+        - id: 6433550
+          name: glycerine/shore-mt
         - id: 32137101
           name: google-code-export/twig-persist
         - id: 48279725
@@ -67,12 +61,8 @@ data:
           name: jankotek/mapdb
         - id: 37340459
           name: jayhopeter/NDatabase
-        - id: 119234782
-          name: jonahharris/osdb-beaglesql
         - id: 1776883
           name: kimchy/compass
-        - id: 442441933
-          name: mabel-dev/opteryx
         - id: 89699591
           name: magma-database/magma
         - id: 25225465
@@ -81,22 +71,14 @@ data:
           name: mateusfreira/nun-db
         - id: 273564373
           name: morecraf/Siaqodb
-        - id: 351806852
-          name: neondatabase/neon
+        - id: 242776849
+          name: oracle/coherence
         - id: 79901405
           name: objectbox/objectbox-java
         - id: 7083240
           name: orientechnologies/orientdb
-        - id: 432844875
-          name: orioledb/orioledb
-        - id: 660776503
-          name: paradedb/paradedb
         - id: 37285717
           name: pilgr/Paper
-        - id: 14702444
-          name: pipelinedb/pipelinedb
-        - id: 927442
-          name: postgres/postgres
         - id: 90349373
           name: profanedb/ProfaneDB
         - id: 1917262

--- a/labeled_data/technology/database/rdf.yml
+++ b/labeled_data/technology/database/rdf.yml
@@ -10,10 +10,14 @@ data:
           name: 4store/4store
         - id: 8335020
           name: BrightstarDB/BrightstarDB
+        - id: 27594187
+          name: ad-freiburg/qlever
         - id: 6235870
           name: ansell/openrdf-sesame
         - id: 7437073
           name: apache/jena
+        - id: 43734923
+          name: apache/rya
         - id: 111333972
           name: arun1729/cog
         - id: 48451041
@@ -36,6 +40,8 @@ data:
           name: gurneyalex/cubicweb
         - id: 754873
           name: njh/redstore
+        - id: 133687025
+          name: oxigraph/oxigraph
         - id: 16710751
           name: quoll/mulgara
         - id: 198466472

--- a/labeled_data/technology/database/relational.yml
+++ b/labeled_data/technology/database/relational.yml
@@ -36,8 +36,14 @@ data:
           name: ALTIBASE/altibase
         - id: 25780780
           name: AlaSQL/alasql
+        - id: 621929252
+          name: ArroyoSystems/arroyo
         - id: 22427082
           name: BTrDB/btrdb-server
+        - id: 883391427
+          name: BemiHQ/BemiDB
+        - id: 150149024
+          name: BlazingDB/blazingsql
         - id: 581145740
           name: ByConity/ByConity
         - id: 52080367
@@ -70,14 +76,20 @@ data:
           name: GreatSQL/GreatSQL
         - id: 274000765
           name: GunterMueller/LEAP_RDBMS
-        - id: 516821813
-          name: HydrasDB/hydra
+        - id: 1188294539
+          name: JagritGumber/evolvsql
         - id: 858418
           name: JakSprats/Alchemy-Database
+        - id: 915978190
+          name: JakeRoggenbuck/RedoxQL
+        - id: 1047223442
+          name: JakeRoggenbuck/kronicler
         - id: 80645561
           name: JuliaData/JuliaDB.jl
         - id: 533032
           name: LinkedInAttic/sensei
+        - id: 3017505
+          name: LucidDB/luciddb
         - id: 19816070
           name: MariaDB/server
         - id: 135423959
@@ -88,6 +100,8 @@ data:
           name: NodeDB-Lab/nodedb
         - id: 684046299
           name: OpenTenBase/OpenTenBase
+        - id: 828849220
+          name: OxidizeLabs/ferrite
         - id: 41443810
           name: Postgres-XL/Postgres-XL
         - id: 605546193
@@ -100,24 +114,34 @@ data:
           name: RhizomeDB/rs-rhizome
         - id: 685897222
           name: Shannon-Data/ShannonBase
-        - id: 42580991
-          name: SnappyDataInc/snappydata
+        - id: 1211492976
+          name: SouravRoy-ETL/slothdb
         - id: 402945349
           name: StarRocks/StarRocks
         - id: 590507334
           name: StereoDB/StereoDB
         - id: 501460708
           name: StoneAtom/stonedb
+        - id: 972754006
+          name: SwellDB/SwellDB
+        - id: 42580991
+          name: TIBCOSoftware/snappydata
         - id: 2445970
           name: VoltDB/voltdb
+        - id: 16326644
+          name: akumuli/Akumuli
         - id: 416777125
           name: alexraffy/sksql
         - id: 692348247
           name: amelielabs/amelie
+        - id: 700017073
+          name: antoniosarosi/mkdb
         - id: 3927863
           name: antonmks/Alenka
         - id: 358917318
           name: apache/arrow-datafusion
+        - id: 644742603
+          name: apache/cloudberry
         - id: 1918497
           name: apache/derby
         - id: 99919302
@@ -130,12 +154,14 @@ data:
           name: apache/hawq
         - id: 206444
           name: apache/hive
+        - id: 496505424
+          name: apache/horaedb
         - id: 56128733
           name: apache/impala
-        - id: 496505424
-          name: apache/incubator-horaedb
         - id: 56214719
           name: apache/incubator-retired-quickstep
+        - id: 17971137
+          name: apache/incubator-tajo
         - id: 50647838
           name: apache/kudu
         - id: 28738447
@@ -156,30 +182,30 @@ data:
           name: apavlo/h-store
         - id: 134193743
           name: apavlo/metalbase
+        - id: 757281035
+          name: ariasql/ariasql
         - id: 40787594
           name: aur-archive/gigabase
+        - id: 1237465314
+          name: ayoubnabil/aiondb
         - id: 143436277
           name: baidu/BaikalDB
         - id: 141378316
           name: beardedeagle/mnesiac
         - id: 16109206
           name: biokoda/actordb
-        - id: 57401138
-          name: bitnine-oss/agensgraph
-        - id: 150149024
-          name: blazingdb/pyBlazing
         - id: 91593042
           name: bloomberg/comdb2
         - id: 92329433
           name: canonical/dqlite
+        - id: 1099507418
+          name: carlosbarbosamexico/narayana
         - id: 372181547
           name: cashapp/pranadb
         - id: 606433492
           name: chdb-io/chdb
         - id: 50874442
           name: citusdata/citus
-        - id: 644742603
-          name: cloudberrydb/cloudberrydb
         - id: 207663235
           name: cmu-db/bustub
         - id: 140325970
@@ -190,20 +216,20 @@ data:
           name: cockroachdb/cockroach
         - id: 296950535
           name: codemix/ts-sql
-        - id: 254418044
-          name: coilhq/tigerbeetle
         - id: 69400326
           name: confluentinc/ksql
         - id: 551374215
           name: cozodb/cozo
         - id: 132361668
           name: cswinter/LocustDB
+        - id: 173582015
+          name: cube2222/octosql
         - id: 14090388
           name: cznic/ql
         - id: 824462634
-          name: darshan117/BroDB
+          name: darshan117/BroSql
         - id: 302827809
-          name: datafuselabs/databend
+          name: databendlabs/databend
         - id: 2894420
           name: deveel/deveeldb
         - id: 52507351
@@ -216,6 +242,8 @@ data:
           name: dremio/dremio-oss
         - id: 138754790
           name: duckdb/duckdb
+        - id: 1268325095
+          name: earonesty/lakeql
         - id: 341208515
           name: edgelesssys/edgelessdb
         - id: 61373806
@@ -232,6 +260,8 @@ data:
           name: eyalroz/c-store
         - id: 172208960
           name: eztools-software/FileDb
+        - id: 13887383
+          name: facebookarchive/webscalesql-5.6
         - id: 388946490
           name: facebookincubator/velox
         - id: 40127179
@@ -249,13 +279,15 @@ data:
         - id: 95817032
           name: geldata/gel
         - id: 148087762
-          name: georgia-tech-db/eva
+          name: georgia-tech-db/evadb
         - id: 3084708
           name: ggaughan/ThinkSQL
         - id: 91715647
           name: gnocchixyz/gnocchi
         - id: 24650236
           name: google/lovefield
+        - id: 14753974
+          name: graemedouglas/LittleD
         - id: 385634291
           name: grafana/mimir
         - id: 805041952
@@ -268,26 +300,34 @@ data:
           name: hpides/skyrise
         - id: 291675222
           name: hstreamdb/hstream
+        - id: 516821813
+          name: hydradatabase/columnar
+        - id: 1101734601
+          name: hyparam/squirreling
         - id: 87414843
           name: hyrise/hyrise
         - id: 13589020
           name: infinidb/infinidb
         - id: 11630463
           name: infinisql/infinisql
+        - id: 1243401750
+          name: infino-ai/infino
         - id: 119234782
           name: jonahharris/osdb-beaglesql
         - id: 119234429
           name: jonahharris/osdb-typhoon
+        - id: 1174651148
+          name: kashyap-devansh/Ark
         - id: 371172777
           name: kelindar/column
         - id: 199466858
           name: kkuchta/tabdb
+        - id: 1193777419
+          name: lasect/discodb
         - id: 591417438
           name: launix-de/memcp
         - id: 7502247
           name: lealone/Lealone
-        - id: 543276238
-          name: libsql/libsql
         - id: 509396909
           name: lingo-db/lingo-db
         - id: 323389945
@@ -308,20 +348,32 @@ data:
           name: matrixorigin/matrixone
         - id: 71015036
           name: mattbostock/timbala
+        - id: 780362035
+          name: maxnilz/sboxdb
         - id: 463071559
           name: minovakovi/akdb
         - id: 62660036
           name: mozilla/mentat
+        - id: 999616035
+          name: multigres/multigres
         - id: 771847852
           name: myscale/MyScaleDB
         - id: 24494032
           name: mysql/mysql-server
+        - id: 460512584
+          name: mzinsmeister/OxidSQL
         - id: 351806852
           name: neondatabase/neon
         - id: 147880351
           name: njaard/sonnerie
+        - id: 31960975
+          name: nukep/llamadb
         - id: 372536760
           name: oceanbase/oceanbase
+        - id: 1080442728
+          name: oceanbase/seekdb
+        - id: 813146214
+          name: open-gpdb/gpdb
         - id: 507829396
           name: openGemini/openGemini
         - id: 276117477
@@ -360,8 +412,10 @@ data:
           name: qikkDB/qikkdb
         - id: 19257422
           name: questdb/questdb
+        - id: 95753144
+          name: quqiangsheng/abhot
         - id: 5665061
-          name: radare/sdb
+          name: radareorg/sdb
         - id: 117920609
           name: radondb/radon
         - id: 206686299
@@ -378,8 +432,16 @@ data:
           name: ryenus/hsqldb
         - id: 2529750
           name: sameeragarwal/blinkdb
+        - id: 1254385987
+          name: shuruheel/mnestic
         - id: 817507312
           name: sirius-db/sirius
+        - id: 57401138
+          name: skaiworldwide-oss/agensgraph
+        - id: 1179701067
+          name: skel84/allocdb
+        - id: 1126115972
+          name: sochdb/sochdb
         - id: 8582237
           name: splicemachine/spliceengine
         - id: 510375115
@@ -404,6 +466,8 @@ data:
           name: taosdata/TDengine
         - id: 285012797
           name: tensorbase/tensorbase
+        - id: 254418044
+          name: tigerbeetle/tigerbeetle
         - id: 678214856
           name: timeplus-io/proton
         - id: 443220240
@@ -412,14 +476,26 @@ data:
           name: traildb/traildb
         - id: 166515022
           name: trinodb/trino
+        - id: 543276238
+          name: tursodatabase/libsql
+        - id: 683347556
+          name: tursodatabase/turso
         - id: 697976
           name: twitter-archive/snowflake
+        - id: 646912783
+          name: ubco-db/EmbedDB
         - id: 149626591
           name: uber/aresdb
         - id: 234910993
           name: vectorengine/vectorsql
+        - id: 975757837
+          name: villagesql/villagesql-server
         - id: 11008207
           name: vitessio/vitess
+        - id: 104114230
+          name: viyadb/viyadb
+        - id: 964004742
+          name: warehouse-pg/warehouse-pg
         - id: 3900741
           name: wundrian/csql
         - id: 19503320

--- a/labeled_data/technology/database/search_engine.yml
+++ b/labeled_data/technology/database/search_engine.yml
@@ -11,6 +11,8 @@ data:
     - name: GitHub
       type: Code Hosting
       repos:
+        - id: 341374920
+          name: apache/solr
         - id: 50229487
           name: apache/lucene-solr
         - id: 507775
@@ -21,10 +23,6 @@ data:
           name: marqo-ai/marqo
         - id: 130688011
           name: meilisearch/meilisearch
-        - id: 334274271
-          name: opensearch-project/OpenSearch
-        - id: 36992044
-          name: sphinxsearch/sphinx
         - id: 79317191
           name: typesense/typesense
         - id: 60377070

--- a/labeled_data/technology/database/vector.yml
+++ b/labeled_data/technology/database/vector.yml
@@ -12,30 +12,60 @@ data:
       repos:
         - id: 753244287
           name: DeployQL/LintDB
+        - id: 40127179
+          name: FeatureBaseDB/featurebase
         - id: 893031915
           name: HelixDB/helix-db
+        - id: 1244916331
+          name: IssunDB/issun-db
+        - id: 1111440285
+          name: MauricioPerera/LOKIVECTOR
         - id: 1183612568
           name: NodeDB-Lab/nodedb
         - id: 1041584089
           name: RijinRaju/octanedb
         - id: 685897222
           name: Shannon-Data/ShannonBase
+        - id: 1182378589
+          name: VincentKaufmann/GitDB
         - id: 201403923
           name: activeloopai/deeplake
         - id: 124315604
           name: aerospike/aerospike-server
+        - id: 1110443421
+          name: alibaba/zvec
+        - id: 1182753977
+          name: antflydb/antfly
         - id: 642912355
           name: awa-ai/awadb
+        - id: 1237465314
+          name: ayoubnabil/aiondb
+        - id: 1296163320
+          name: barrel-db/barrel
+        - id: 18893367
+          name: blevesearch/bleve
         - id: 793209340
           name: carsonpo/haystackdb
         - id: 546206616
           name: chroma-core/chroma
+        - id: 722854801
+          name: edwinkys/oasysdb
+        - id: 1141278752
+          name: endee-io/endee
         - id: 304530333
-          name: featureform/embeddinghub
+          name: featureform/featureform
+        - id: 1150783842
+          name: ferres-db/ferres-db
+        - id: 1208697458
+          name: hexxla/hexxladb
+        - id: 869784587
+          name: hicder/muopdb
         - id: 628503457
           name: jdagdelen/hyperDB
         - id: 635374751
           name: jina-ai/vectordb
+        - id: 1210826829
+          name: jose-compu/logosdb
         - id: 632269609
           name: kagisearch/vectordb
         - id: 242383787
@@ -44,21 +74,29 @@ data:
           name: marqo-ai/marqo
         - id: 208728772
           name: milvus-io/milvus
+        - id: 1201033913
+          name: nambok/mentedb
+        - id: 1108658403
+          name: nubskr/satoriDB
         - id: 478288303
           name: nuclia/nucliadb
-        - id: 722854801
-          name: oasysai/oasysdb
+        - id: 1080442728
+          name: oceanbase/seekdb
         - id: 735283134
           name: philippgille/chromem-go
-        - id: 40127179
-          name: pilosa/pilosa
         - id: 268163609
           name: qdrant/qdrant
-        - id: 55072677
-          name: semi-technologies/weaviate
+        - id: 1126115972
+          name: sochdb/sochdb
         - id: 195619075
           name: vdaas/vald
         - id: 186332888
           name: vearch/vearch
         - id: 634656527
           name: vector5ai/vector5db
+        - id: 55072677
+          name: weaviate/weaviate
+        - id: 1164482810
+          name: yantrikos/yantrikdb
+        - id: 1242559745
+          name: zaydmulani09/vecdb

--- a/labeled_data/technology/database/wide_column.yml
+++ b/labeled_data/technology/database/wide_column.yml
@@ -38,20 +38,26 @@ data:
           name: baidu/tera
         - id: 182849188
           name: delta-io/delta
-        - id: 191676087
-          name: eleme/lindb
         - id: 1584552
           name: hypertable/hypertable
         - id: 13124802
           name: influxdata/influxdb
+        - id: 8039659
+          name: kairosdb/kairosdb
         - id: 191442206
           name: kashirin-alex/swc-db
+        - id: 1230283259
+          name: katehonz/barabaDB
+        - id: 191676087
+          name: lindb/lindb
         - id: 473235285
           name: polarsignals/frostdb
         - id: 5349565
           name: prestodb/presto
+        - id: 10081109
+          name: rax-maas/blueflood
         - id: 28449431
-          name: scylladb/scylla
+          name: scylladb/scylladb
         - id: 41209174
           name: strapdata/elassandra
         - id: 872645739


### PR DESCRIPTION
Fix https://github.com/X-lab2017/open-digger/issues/1793

Batch label data: Incrementally add labeled repositories into the database technology.
## Update Data: 
  - Update labeled data of Opensource DBMS with a github repo link, based on dbdb.io and DB-Engines up to August 8, 2026 for July. 

## **Filter conditions**: 
- Collected by dbdb.io on August 8, 2026 OR Listed in the DB-Engines Rankings table on July 31, 2026; 
- Has open source license; 
- Has repository link on GitHub; 
- The increment relative to the version https://github.com/X-lab2017/open-digger/issues/1784 on June 30, 2026 (or May 31, 2026 with no changes to the label data).

## Summary

- Updated 11 database label files: Array, Document, Graph, Hierarchical, Key-value, Object Oriented, RDF, Relational, Search Engine, Vector, Wide Column.
- Added 99 repositories.
- Removed 2 repositories.
- Updated 43 repository names for existing GitHub repo ids.
- Changed label-repo records: +178, -69.
- Repo ids were queried from the GitHub REST API: `https://api.github.com/repos/{owner}/{repo}`.

### Change List

<details>
<summary>Renamed repositories: 43</summary>

- `apache/incubator-horaedb` -> `apache/horaedb` (`id: 496505424`; labels: Relational)
- `apache/incubator-hugegraph` -> `apache/hugegraph` (`id: 141376301`; labels: Graph)
- `badgerman/ennodb` -> `ennorehling/ennodb` (`id: 6768410`; labels: Key-value)
- `bitnine-oss/agensgraph` -> `skaiworldwide-oss/agensgraph` (`id: 57401138`; labels: Document, Graph, Key-value, Relational)
- `blazingdb/pyBlazing` -> `BlazingDB/blazingsql` (`id: 150149024`; labels: Relational)
- `c9fe/sirdb` -> `DO-SAY-GO/sirdb` (`id: 234091935`; labels: Document)
- `cloudberrydb/cloudberrydb` -> `apache/cloudberry` (`id: 644742603`; labels: Object Oriented, Relational)
- `coilhq/tigerbeetle` -> `tigerbeetle/tigerbeetle` (`id: 254418044`; labels: Relational)
- `dappkit/aviondb` -> `aviondb/aviondb` (`id: 249981301`; labels: Document)
- `darshan117/BroDB` -> `darshan117/BroSql` (`id: 824462634`; labels: Relational)
- `datafuselabs/databend` -> `databendlabs/databend` (`id: 302827809`; labels: Relational)
- `dicedb/dice` -> `dicedb/dicedb` (`id: 531220682`; labels: Key-value)
- `eleme/lindb` -> `lindb/lindb` (`id: 191676087`; labels: Wide Column)
- `featurebasedb/featurebase` / `pilosa/pilosa` -> `FeatureBaseDB/featurebase` / `featurebasedb/featurebase` (`id: 40127179`; labels: Relational, Vector)
- `featureform/embeddinghub` -> `featureform/featureform` (`id: 304530333`; labels: Vector)
- `genjidb/genji` -> `chaisql/chai` (`id: 138411034`; labels: Document)
- `georgia-tech-db/eva` -> `georgia-tech-db/evadb` (`id: 148087762`; labels: Relational)
- `Greg0/Lazer-Database` -> `Lazer-Database/Lazer-Database` (`id: 8313554`; labels: Document)
- `hivedb/hive` -> `isar/hive` (`id: 195895847`; labels: Key-value)
- `HydrasDB/hydra` -> `hydradatabase/columnar` (`id: 516821813`; labels: Object Oriented, Relational)
- `juji-io/datalevin` -> `datalevin/datalevin` (`id: 270858421`; labels: Document)
- `KvrocksLabs/kvrocks` -> `apache/kvrocks` (`id: 202483348`; labels: Key-value)
- `libsql/libsql` -> `tursodatabase/libsql` (`id: 543276238`; labels: Relational)
- `mbdavid/LiteDB` -> `litedb-org/LiteDB` (`id: 23315232`; labels: Document)
- `oasysai/oasysdb` -> `edwinkys/oasysdb` (`id: 722854801`; labels: Key-value, Vector)
- `orbitdb/orbit-db` -> `orbitdb/orbitdb` (`id: 48617634`; labels: Document, Key-value)
- `pouchdb/pouchdb` -> `apache/pouchdb` (`id: 714074`; labels: Document)
- `Qihoo360/pika` -> `OpenAtomFoundation/pikiwidb` (`id: 26127968`; labels: Key-value)
- `radare/sdb` -> `radareorg/sdb` (`id: 5665061`; labels: Document, Relational)
- `rakibtg/SleekDB` -> `SleekDB/SleekDB` (`id: 129436009`; labels: Document)
- `resilientdb/resilientdb` -> `apache/incubator-resilientdb` (`id: 223462217`; labels: Document)
- `roseduan/rosedb` -> `rosedblabs/rosedb` (`id: 318972528`; labels: Key-value)
- `scratchdata/ScratchDB` -> `scratchdata/scratchdata` (`id: 664816265`; labels: Document)
- `scylladb/scylla` -> `scylladb/scylladb` (`id: 28449431`; labels: Key-value, Wide Column)
- `semi-technologies/weaviate` -> `weaviate/weaviate` (`id: 55072677`; labels: Vector)
- `SnappyDataInc/snappydata` -> `TIBCOSoftware/snappydata` (`id: 42580991`; labels: Relational)
- `streamnative/oxia` -> `oxia-db/oxia` (`id: 454981666`; labels: Key-value)
- `stripe/sequins` -> `stripe-archive/sequins` (`id: 26888631`; labels: Key-value)
- `unnamed38/fueldb` -> `jbasiglio/fueldb` (`id: 25364889`; labels: Document)
- `web3-storage/pail` -> `storacha/pail` (`id: 580788054`; labels: Key-value)
- `xujiajun/nutsdb` -> `nutsdb/nutsdb` (`id: 160784930`; labels: Key-value)
- `youtrackdb/youtrackdb` -> `JetBrains/youtrackdb` (`id: 759929648`; labels: Graph)
- `zerodb/zerodb` -> `nucypher/zerodb` (`id: 47479424`; labels: Document)

</details>

<details>
<summary>Added repositories: 99</summary>

- `539hex/zu` (`id: 981319788`; labels: Key-value)
- `ad-freiburg/qlever` (`id: 27594187`; labels: Graph, RDF)
- `akumuli/Akumuli` (`id: 16326644`; labels: Relational)
- `alibaba/neug` (`id: 1170374747`; labels: Graph)
- `alibaba/zvec` (`id: 1110443421`; labels: Vector)
- `antflydb/antfly` (`id: 1182753977`; labels: Graph, Vector)
- `antithesishq/valthree` (`id: 1034637202`; labels: Key-value)
- `antoniosarosi/mkdb` (`id: 700017073`; labels: Relational)
- `apache/incubator-tajo` (`id: 17971137`; labels: Relational)
- `apache/rya` (`id: 43734923`; labels: RDF)
- `apache/solr` (`id: 341374920`; labels: Document, Search Engine)
- `ariasql/ariasql` (`id: 757281035`; labels: Relational)
- `ArroyoSystems/arroyo` (`id: 621929252`; labels: Relational)
- `ayoubnabil/aiondb` (`id: 1237465314`; labels: Graph, Relational, Vector)
- `barrel-db/barrel` (`id: 1296163320`; labels: Document, Vector)
- `basho/bitcask` (`id: 632037`; labels: Key-value)
- `BemiHQ/BemiDB` (`id: 883391427`; labels: Relational)
- `blevesearch/bleve` (`id: 18893367`; labels: Document, Vector)
- `carlosbarbosamexico/narayana` (`id: 1099507418`; labels: Relational)
- `cockroachdb/pebble` (`id: 141339868`; labels: Key-value)
- `cube2222/octosql` (`id: 173582015`; labels: Relational)
- `dlitz/resin` (`id: 3115025`; labels: Key-value)
- `documentdb/documentdb` (`id: 920805662`; labels: Document)
- `earonesty/lakeql` (`id: 1268325095`; labels: Relational)
- `endee-io/endee` (`id: 1141278752`; labels: Vector)
- `estebanrfp/gdb` (`id: 590923204`; labels: Graph)
- `ExtendDB/extenddb` (`id: 1234582852`; labels: Document, Key-value)
- `facebookarchive/webscalesql-5.6` (`id: 13887383`; labels: Relational)
- `ferres-db/ferres-db` (`id: 1150783842`; labels: Vector)
- `glycerine/shore-mt` (`id: 6433550`; labels: Object Oriented)
- `GNS-Foundation/mobydb` (`id: 1199943658`; labels: Key-value)
- `graemedouglas/LittleD` (`id: 14753974`; labels: Relational)
- `GraphLite-AI/GraphLite` (`id: 1096820313`; labels: Graph)
- `guycipher/k4` (`id: 879526764`; labels: Key-value)
- `hexxla/hexxladb` (`id: 1208697458`; labels: Array, Vector)
- `hicder/muopdb` (`id: 869784587`; labels: Vector)
- `hydraide/hydraide` (`id: 952556108`; labels: Key-value)
- `hyparam/squirreling` (`id: 1101734601`; labels: Relational)
- `inder/salvobase` (`id: 1171244520`; labels: Document)
- `infino-ai/infino` (`id: 1243401750`; labels: Relational)
- `IssunDB/issun-db` (`id: 1244916331`; labels: Graph, Vector)
- `JagritGumber/evolvsql` (`id: 1188294539`; labels: Relational)
- `JakeRoggenbuck/kronicler` (`id: 1047223442`; labels: Relational)
- `JakeRoggenbuck/RedoxQL` (`id: 915978190`; labels: Relational)
- `jose-compu/logosdb` (`id: 1210826829`; labels: Vector)
- `kairosdb/kairosdb` (`id: 8039659`; labels: Key-value, Wide Column)
- `kashyap-devansh/Ark` (`id: 1174651148`; labels: Relational)
- `katehonz/barabaDB` (`id: 1230283259`; labels: Document, Graph, Wide Column)
- `kurrent-io/KurrentDB` (`id: 5844474`; labels: Document)
- `lasect/discodb` (`id: 1193777419`; labels: Relational)
- `leanstore/leanstore` (`id: 328647920`; labels: Key-value)
- `lispking/kvdb` (`id: 1198485229`; labels: Key-value)
- `Log2n-io/Typhon` (`id: 366298992`; labels: Object Oriented)
- `lotusdblabs/lotusdb` (`id: 438128602`; labels: Key-value)
- `LucidDB/luciddb` (`id: 3017505`; labels: Relational)
- `MauricioPerera/LOKIVECTOR` (`id: 1111440285`; labels: Document, Vector)
- `maxnilz/sboxdb` (`id: 780362035`; labels: Relational)
- `multigres/multigres` (`id: 999616035`; labels: Relational)
- `mzinsmeister/OxidSQL` (`id: 460512584`; labels: Relational)
- `nambok/mentedb` (`id: 1201033913`; labels: Graph, Vector)
- `namidb/namidb` (`id: 1242792159`; labels: Graph)
- `Netflix/dynomite` (`id: 13484625`; labels: Key-value)
- `nubskr/nubmq` (`id: 858384155`; labels: Key-value)
- `nubskr/satoriDB` (`id: 1108658403`; labels: Vector)
- `nukep/llamadb` (`id: 31960975`; labels: Relational)
- `NumstoreDB/Numstore` (`id: 1211040071`; labels: Array)
- `oceanbase/seekdb` (`id: 1080442728`; labels: Relational, Vector)
- `open-gpdb/gpdb` (`id: 813146214`; labels: Relational)
- `outr/HaloDB` (`id: 891723751`; labels: Key-value)
- `OxidizeLabs/ferrite` (`id: 828849220`; labels: Relational)
- `oxigraph/oxigraph` (`id: 133687025`; labels: Graph, RDF)
- `pmwkaa/sophia` (`id: 12843155`; labels: Key-value)
- `quqiangsheng/abhot` (`id: 95753144`; labels: Relational)
- `rax-maas/blueflood` (`id: 10081109`; labels: Key-value, Wide Column)
- `replikativ/datahike` (`id: 116407410`; labels: Key-value)
- `Schema-JS/schema-js` (`id: 836018246`; labels: Document)
- `shuruheel/mnestic` (`id: 1254385987`; labels: Relational)
- `skel84/allocdb` (`id: 1179701067`; labels: Relational)
- `sklad-dev/Sklad` (`id: 942380667`; labels: Key-value)
- `sochdb/sochdb` (`id: 1126115972`; labels: Graph, Relational, Vector)
- `softmaxdata/engram` (`id: 1169046116`; labels: Graph)
- `SouravRoy-ETL/slothdb` (`id: 1211492976`; labels: Relational)
- `spotify/sparkey` (`id: 12488811`; labels: Key-value)
- `SwellDB/SwellDB` (`id: 972754006`; labels: Relational)
- `Tencent/MMKV` (`id: 149111813`; labels: Key-value)
- `thetarby/helindb` (`id: 426652249`; labels: Key-value)
- `tidwall/pogocache` (`id: 1023788092`; labels: Key-value)
- `TieredMemDB/TieredMemDB` (`id: 415886839`; labels: Key-value)
- `Tokutek/mongo` (`id: 8729689`; labels: Document)
- `tursodatabase/turso` (`id: 683347556`; labels: Relational)
- `ubco-db/EmbedDB` (`id: 646912783`; labels: Relational)
- `Unconcurrent/SoloDB` (`id: 813243891`; labels: Document)
- `villagesql/villagesql-server` (`id: 975757837`; labels: Relational)
- `VincentKaufmann/GitDB` (`id: 1182378589`; labels: Document, Vector)
- `viyadb/viyadb` (`id: 104114230`; labels: Relational)
- `volcengine/OpenViking` (`id: 1128123594`; labels: Hierarchical)
- `warehouse-pg/warehouse-pg` (`id: 964004742`; labels: Relational)
- `yantrikos/yantrikdb` (`id: 1164482810`; labels: Graph, Key-value, Vector)
- `zaydmulani09/vecdb` (`id: 1242559745`; labels: Document, Vector)

</details>

<details>
<summary>Removed repositories: 2</summary>

- `petermattis/pebble` (`id: 278684767`; labels: Key-value). Reason: Not restored because both `https://api.github.com/repos/petermattis/pebble` and `https://api.github.com/repositories/278684767` return 404.
- `xap/xap` (`id: 65259211`; labels: Key-value). Reason: Not restored because both `https://api.github.com/repos/xap/xap` and `https://api.github.com/repositories/65259211` return 404.

</details>

## Changed Files

- `labeled_data/technology/database/array.yml`
- `labeled_data/technology/database/document.yml`
- `labeled_data/technology/database/graph.yml`
- `labeled_data/technology/database/hierarchical.yml`
- `labeled_data/technology/database/key_value.yml`
- `labeled_data/technology/database/object_oriented.yml`
- `labeled_data/technology/database/rdf.yml`
- `labeled_data/technology/database/relational.yml`
- `labeled_data/technology/database/search_engine.yml`
- `labeled_data/technology/database/vector.yml`
- `labeled_data/technology/database/wide_column.yml`

## Validation

- Regenerated the parsed GitHub repo id data from `issue_body_format.txt`.
- Verified all changed database YAML files can be parsed as YAML.
- Preserved existing OpenDigger entries that remain accessible or manually confirmed; see local restore audit `temp/pr_1793_restore_needed.md`.
- Did not restore removed entries whose repository URL API and repository id API both return 404.
 
## Notes
- The repo_id is queried from `repository_url` api `https://api.github.com/repos/{owner}/{repo}`.
